### PR TITLE
Enable Secure System Time

### DIFF
--- a/meta-dstack/recipes-core/chrony/chrony%.bbappend
+++ b/meta-dstack/recipes-core/chrony/chrony%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+DEPENDS += "gnutls"

--- a/meta-dstack/recipes-core/chrony/files/chrony.conf
+++ b/meta-dstack/recipes-core/chrony/files/chrony.conf
@@ -1,0 +1,59 @@
+# Load config files matching the /etc/chrony/conf.d/*.conf pattern.
+confdir /etc/chrony/conf.d
+
+# Use public NTP servers from the pool.ntp.org project.
+# Please consider joining the pool project if possible by running your own
+# server(s).
+# If you are a vendor distributing a product using chrony, you *MUST*
+# read and comply with http://www.pool.ntp.org/vendors.html
+# pool 0.openembedded.pool.ntp.org iburst
+
+# Use a local timeserver in preference to the pool, if it's reachable.
+#server 192.168.22.22 iburst minpoll 2 prefer
+server time.cloudflare.com iburst nts
+server nts.teambelgium.net iburst nts
+server a.st1.ntp.br iburst nts
+server time.bolha.one iburst nts
+server ptbtime1.ptb.de iburst nts
+server ntp2.glypnod.com iburst nts
+server ntp1.glypnod.com iburst nts
+server virginia.time.system76.com iburst nts
+
+# Sync to pulse-per-second from an onboard GPS.
+#refclock PPS /dev/pps0 poll 0 prefer
+# You'll want to enable CONFIG_PPS and CONFIG_PPS_CLIENT_GPIO in your kernel,
+# and an entry something like this in your device tree:
+#	pps {
+#		compatible = "pps-gpio";
+#		gpios = <&ps7_gpio_0 56 0>;
+#	};
+
+# Load source files matching the /etc/chrony/sources.d/*.sources pattern.
+# These can be reloaded using 'chronyc reload sources'.
+sourcedir /etc/chrony/sources.d
+
+# In first three updates step the system clock instead of slew
+# if the adjustment is larger than 1 second.
+makestep 1.0 3
+
+# Record the rate at which the system clock gains/loses time,
+# improving accuracy after reboot
+driftfile /var/lib/chrony/drift
+
+# Enable kernel synchronization of the hardware real-time clock (RTC).
+# rtcsync
+
+# Allow NTP client access from local network.
+#allow 192.168/16
+
+# Serve time even if not synchronized to any NTP server.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/meta-dstack/recipes-core/images/dstack-initramfs-files/init
+++ b/meta-dstack/recipes-core/images/dstack-initramfs-files/init
@@ -21,6 +21,7 @@ mount -t devpts devpts /dev/pts
 ifconfig lo up 127.0.0.1
 ifconfig eth0 up
 udhcpc -i eth0
+chronyd -q
 
 modprobe tdx-guest || true
 

--- a/meta-dstack/recipes-core/images/dstack-initramfs.bb
+++ b/meta-dstack/recipes-core/images/dstack-initramfs.bb
@@ -13,6 +13,7 @@ PACKAGE_INSTALL = "\
     dstack-guest \
     curl \
     jq \
+    chrony \
 "
 
 # Do not pollute the initrd image with rootfs features

--- a/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
+++ b/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
@@ -16,6 +16,7 @@ IMAGE_INSTALL = "\
     wireguard-tools \
     curl \
     jq \
+    chrony \
     qemu-guest-agent \
 "
 

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -91,11 +91,16 @@ $Q makeiso ${WORK_DIR}/rootfs/ ${OUTPUT_DIR}/rootfs.iso
 
 GIT_REVISION=$(git rev-parse HEAD)
 echo "Generating metadata.json to ${OUTPUT_DIR}/metadata.json"
+
+KARG0="console=ttyS0 init=/init panic=1 systemd.unified_cgroup_hierarchy=0 pnpacpi=off"
+KARG1="mce=off oops=panic pci=noearly pci=nommconf random.trust_cpu=y random.trust_bootloader=n tsc=reliable no-kvmclock"
+KARG2="dstack.fde=1 dstack.rootfs_hash=$ROOTFS_HASH"
+
 cat <<EOF > ${OUTPUT_DIR}/metadata.json
 {
     "bios": "ovmf.fd",
     "kernel": "bzImage",
-    "cmdline": "console=ttyS0 init=/init panic=1 systemd.unified_cgroup_hierarchy=0 pnpacpi=off dstack.fde=1 dstack.rootfs_hash=$ROOTFS_HASH",
+    "cmdline": "$KARG0 $KARG1 $KARG2",
     "initrd": "initramfs.cpio.gz",
     "rootfs": "rootfs.iso",
     "rootfs_hash": "$ROOTFS_HASH",


### PR DESCRIPTION
According to the [doc](https://intel.github.io/ccc-linux-guest-hardening-docs/security-spec.html#tsc-and-other-timers) from Intel, the TSC inside TD is secure if it is synchronized with NTS.

This PR makes the TD system time secure by:
- Disabling kvm-clock so that the TD guest kernel uses TSC as the only clock source.
- Synchronizing the system time using chrony with NTS in initrd, if it fails, rejecting to boot.
- Adding chrony as a systemd service

TODO: Terminate the system upon prolonged chrony synchronization failure to prevent clock drift.