### PR TITLE
Fix reproducible issues for rootfs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/Dstack-TEE/dstack
 [submodule "meta-security"]
 	path = meta-security
-	url = https://git.yoctoproject.org/meta-security
+	url = https://github.com/Dstack-TEE/meta-security.git

--- a/meta-dstack/recipes-core/images/dstack-initscript/init
+++ b/meta-dstack/recipes-core/images/dstack-initscript/init
@@ -39,7 +39,7 @@ echo "  Data size: ${DATA_SIZE}"
 veritysetup open ${ROOT_DEV} rootfs ${ROOT_DEV} "${ROOT_HASH}" --hash-offset="${DATA_SIZE}"
 
 echo "Mounting rootfs..."
-mount -t ext4 -o ro /dev/mapper/rootfs ${ROOT_DIR}
+mount -t squashfs /dev/mapper/rootfs ${ROOT_DIR}
 
 mount_move_all() {
     for dir in $@; do

--- a/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
+++ b/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
@@ -34,12 +34,13 @@ LICENSE = "MIT"
 IMAGE_CLASSES += "dm-verity-img"
 
 DM_VERITY_IMAGE = "${PN}"
-DM_VERITY_IMAGE_TYPE = "ext4"
+DM_VERITY_IMAGE_TYPE = "squashfs"
 DM_VERITY_SEPARATE_HASH = "0"
+DM_VERITY_REPRODUCIBLE = "1"
 
-IMAGE_FSTYPES = "cpio ext4"
+IMAGE_FSTYPES = "cpio squashfs"
 CONVERSIONTYPES += "verity"
-IMAGE_TYPES += "ext4.verity"
+IMAGE_TYPES += "squashfs.verity"
 
 EXTRA_IMAGE_FEATURES = "read-only-rootfs"
 

--- a/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
+++ b/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
@@ -10,6 +10,7 @@ SRC_URI += "file://dstack-docker.cfg \
 KERNEL_FEATURES:append = " features/cgroups/cgroups.scc \
                           features/overlayfs/overlayfs.scc \
                           features/netfilter/netfilter.scc \
+                          cfg/fs/squashfs.scc \
                           dstack-docker.scc \
                           dstack.scc"
 

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -38,11 +38,11 @@ IMG_DIR=${BB_BUILD_DIR}/tmp/deploy/images/tdx
 ROOTFS_IMAGE_NAME=${DIST_NAME}-rootfs
 
 INITRAMFS_IMAGE=${IMG_DIR}/dstack-initramfs.cpio.gz
-ROOTFS_IMAGE=${IMG_DIR}/${ROOTFS_IMAGE_NAME}-tdx.ext4.verity
+ROOTFS_IMAGE=${IMG_DIR}/${ROOTFS_IMAGE_NAME}-tdx.squashfs.verity
 KERNEL_IMAGE=${IMG_DIR}/bzImage
 OVMF_FIRMWARE=${IMG_DIR}/ovmf.fd
 # Always use the work-shared directory which has the correct verity env
-VERITY_ENV_FILE=${BB_BUILD_DIR}/tmp/work-shared/tdx/dm-verity/${ROOTFS_IMAGE_NAME}.ext4.verity.env
+VERITY_ENV_FILE=${BB_BUILD_DIR}/tmp/work-shared/tdx/dm-verity/${ROOTFS_IMAGE_NAME}.squashfs.verity.env
 echo "Loading verity env from ${VERITY_ENV_FILE}"
 source ${VERITY_ENV_FILE}
 


### PR DESCRIPTION
- Switching to squashfs instead of ext4 for rootfs, so that the filesystem image is deterministic.
- Adding uuid and salt to meta-security to enable reproducible build.