### PR TITLE
Alias passwd files to /etc/users

### DIFF
--- a/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
+++ b/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
@@ -56,7 +56,7 @@ COMPATIBLE_HOST = "x86_64.*-linux"
 ROOTFS_POSTPROCESS_COMMAND += "remove_sysvinit_files;"
 ROOTFS_POSTPROCESS_COMMAND += "symlink_lib64;"
 IMAGE_FEATURES[validitems] += "nologin"
-ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains_any("IMAGE_FEATURES", [ 'nologin' ], "disable_getty_services", "",d)}'
+ROOTFS_POSTPROCESS_COMMAND += '${@bb.utils.contains_any("IMAGE_FEATURES", [ 'nologin' ], "disable_login", "",d)}'
 ROOTFS_POSTPROCESS_COMMAND += "mkdirs;"
 
 
@@ -77,7 +77,7 @@ symlink_lib64() {
     ln -s lib ${IMAGE_ROOTFS}/lib64
 }
 
-disable_getty_services() {
+disable_login() {
     for srv in getty getty-pre; do
         rm -f ${IMAGE_ROOTFS}/etc/systemd/system/${srv}.target
         rm -f ${IMAGE_ROOTFS}/usr/lib/systemd/system/${srv}.target
@@ -135,4 +135,11 @@ mkdirs() {
     mkdir -p ${IMAGE_ROOTFS}/etc/wireguard
     mkdir -p ${IMAGE_ROOTFS}/var/lib/docker
     ln -sf dstack ${IMAGE_ROOTFS}/tapp
+
+    # Aliases passwd files to a subdirectory
+    mkdir -p ${IMAGE_ROOTFS}/etc/users
+    mv ${IMAGE_ROOTFS}/etc/passwd ${IMAGE_ROOTFS}/etc/users/
+    mv ${IMAGE_ROOTFS}/etc/shadow ${IMAGE_ROOTFS}/etc/users/
+    ln -s users/passwd ${IMAGE_ROOTFS}/etc/passwd
+    ln -s users/shadow ${IMAGE_ROOTFS}/etc/shadow
 }


### PR DESCRIPTION
So that it can be mounted to a dir in persistent disk.