### PR TITLE
docker: Pin to single-core and enable pigz

### DIFF
--- a/meta-dstack/recipes-core/docker/docker-moby%.bbappend
+++ b/meta-dstack/recipes-core/docker/docker-moby%.bbappend
@@ -1,1 +1,13 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
 SYSTEMD_SERVICE:${PN}:append = " docker.service"
+
+SRC_URI += "file://docker.service.d_override.conf"
+FILES:${PN} += "${systemd_system_unitdir}/docker.service.d/override.conf"
+
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -d ${D}${systemd_system_unitdir}/docker.service.d
+        install -m 0644 ${WORKDIR}/docker.service.d_override.conf ${D}${systemd_system_unitdir}/docker.service.d/override.conf
+    fi
+}

--- a/meta-dstack/recipes-core/docker/files/docker.service.d_override.conf
+++ b/meta-dstack/recipes-core/docker/files/docker.service.d_override.conf
@@ -1,0 +1,3 @@
+[Service]
+# Pin Docker daemon to CPU 0 for performance isolation
+CPUAffinity=0

--- a/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
+++ b/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
@@ -25,6 +25,7 @@ IMAGE_INSTALL = "\
     kernel-module-fuse \
     fuse3 \
     fuse3-utils \
+    pigz \
 "
 
 IMAGE_NAME_SUFFIX ?= ""


### PR DESCRIPTION
This PR significantly accelerates Docker image pulls through two optimizations:
- enabling pigz
- pinning dockerd to single-core

Testing with `python:latest` (300MB) on an 8-core CVM:
Original time: `1m30s`
With pigz: `1m`
With single-core pinning: `18s`

pulling `kvin/cuda-notebook` (10GB): `15m43.078s` -> `3m18.380s`