### PR TITLE
Update pahole to 1.29

### DIFF
--- a/meta-dstack/recipes-core/pahole/pahole_1.25.bbappend
+++ b/meta-dstack/recipes-core/pahole/pahole_1.25.bbappend
@@ -1,0 +1,2 @@
+# Update pahole to 1.29 for BTF reproducible build
+SRCREV = "b9cc7963051b2099795129450f9b70c81950d02f"


### PR DESCRIPTION
The kernel reproducibility was broken due to the enabling of BTF in PR https://github.com/Dstack-TEE/meta-dstack/pull/12.
This PR fixes it by upgrading the debug info build tool pahole to the latest version 1.29, which supports reproducible builds.