### PR TITLE
Add parted to fix disk growing failure

### DIFF
--- a/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
+++ b/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
@@ -34,6 +34,7 @@ IMAGE_INSTALL = "\
     e2fsprogs \
     e2fsprogs-resize2fs \
     gptfdisk \
+    parted \
 "
 
 IMAGE_NAME_SUFFIX ?= ""


### PR DESCRIPTION
## Summary
- Add `parted` package to the rootfs image to fix disk growing failure

## Test plan
- [x] Build the image and verify `parted` is included
- [x] Test disk grow operation succeeds on a deployed CVM