### PR TITLE
kernel: enable idmapped mounts on overlayfs for sysbox

### DIFF
--- a/meta-dstack/recipes-kernel/linux/files/0002-overlayfs-enable-idmapped-mounts.patch
+++ b/meta-dstack/recipes-kernel/linux/files/0002-overlayfs-enable-idmapped-mounts.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kevin Wang <kvin@phala.network>
+Date: Tue, 4 Mar 2026 00:00:00 +0000
+Subject: [PATCH] overlayfs: add FS_ALLOW_IDMAP to enable idmapped mounts
+
+Overlayfs already has comprehensive support for idmapped mounts through
+its handling of idmapped layers (since 5.19), but it is missing the
+FS_ALLOW_IDMAP flag on ovl_fs_type.  Without this flag the VFS rejects
+mount_setattr(MOUNT_ATTR_IDMAP) on overlay mounts with -EINVAL, which
+prevents container runtimes such as Sysbox from applying transparent UID
+shifting to the container rootfs overlay.
+
+Add FS_ALLOW_IDMAP so that the idmap machinery is available on the
+overlay mount itself, not only on its component layers.
+
+Upstream-Status: Submitted [https://lkml.org/lkml/2025/8/15/1218]
+Signed-off-by: Kevin Wang <kvin@phala.network>
+---
+ fs/overlayfs/super.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/fs/overlayfs/super.c b/fs/overlayfs/super.c
+index 1a530c5a4e02..b7d8e5c91234 100644
+--- a/fs/overlayfs/super.c
++++ b/fs/overlayfs/super.c
+@@ -1484,7 +1484,7 @@ struct file_system_type ovl_fs_type = {
+ 	.name			= "overlay",
+ 	.init_fs_context	= ovl_init_fs_context,
+ 	.parameters		= ovl_parameter_spec,
+-	.fs_flags		= FS_USERNS_MOUNT,
++	.fs_flags		= FS_USERNS_MOUNT | FS_ALLOW_IDMAP,
+ 	.kill_sb		= kill_anon_super,
+ };
+ MODULE_ALIAS_FS("overlay");
+--
+2.46.0

--- a/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
+++ b/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
@@ -9,7 +9,8 @@ SRC_URI += "file://dstack-docker.cfg \
             file://dstack-sysbox.cfg \
             file://dstack-sysbox.scc \
             file://dstack.cfg \
-            file://dstack.scc"
+            file://dstack.scc \
+            file://0002-overlayfs-enable-idmapped-mounts.patch"
 
 KERNEL_FEATURES:append = " features/cgroups/cgroups.scc \
                           features/overlayfs/overlayfs.scc \


### PR DESCRIPTION
## Summary
- Add `FS_ALLOW_IDMAP` flag to overlayfs `ovl_fs_type` in the kernel, enabling `mount_setattr(MOUNT_ATTR_IDMAP)` on overlay mounts
- This fixes sysbox container rootfs UID mapping: without this patch, sysbox's ID-mapped mount detection passes but the actual `mount_setattr()` call silently fails with `EINVAL`, causing image layer files to appear as `nobody:nogroup` inside containers

## Root cause
Upstream Linux (including 6.9 and 6.17) has never set `FS_ALLOW_IDMAP` on overlayfs. A [patch](https://lkml.org/lkml/2025/8/15/1218) was submitted to LKML in Aug 2025 but has not been merged yet. Sysbox detects "Overlayfs on ID-mapped mounts supported: yes" (by testing a different operation — creating overlay with ID-mapped layers) but at runtime tries to ID-map the existing overlay mount, which requires `FS_ALLOW_IDMAP`.

## Test plan
- [ ] Verify `mount_setattr(MOUNT_ATTR_IDMAP)` succeeds on overlay mounts with the patched kernel
- [ ] Verify sysbox containers show correct file ownership (not `nobody:nogroup`) for image layer files
- [ ] Verify xrdp/web RDP works without manual certificate fixes after container restart