### PR TITLE
nvidia: re-enable security LDFLAGS while keeping lazy binding

### DIFF
--- a/meta-nvidia/recipes-graphics/libnvidia-container/libnvidia-container_1.00.bb
+++ b/meta-nvidia/recipes-graphics/libnvidia-container/libnvidia-container_1.00.bb
@@ -16,7 +16,7 @@ CFLAGS:prepend = " -I${RECIPE_SYSROOT_NATIVE}/usr/include/tirpc "
 
 export OBJCPY="${OBJCOPY}"
 GO_IMPORT = "github.com/NVIDIA/nvidia-container-toolkit"
-SECURITY_LDFLAGS = ""
+# Keep lazy binding for Go/CGo compatibility while preserving other security hardening flags.
 LDFLAGS += "-Wl,-z,lazy"
 GO_LINKSHARED = ""
 REQUIRED_DISTRO_FEATURES = "virtualization"

--- a/meta-nvidia/recipes-graphics/nvidia-container-toolkit/nvidia-container-toolkit_1.00.bb
+++ b/meta-nvidia/recipes-graphics/nvidia-container-toolkit/nvidia-container-toolkit_1.00.bb
@@ -3,8 +3,8 @@ require nvidia-container-toolkit.inc
 SUMMARY = "NVIDIA Container Toolkit for Yocto"
 
 GO_INSTALL = "${GO_IMPORT}/cmd/..."
-# The go-nvml symbol lookup functions *require* lazy dynamic symbol resolution
-SECURITY_LDFLAGS = ""
+# The go-nvml symbol lookup functions *require* lazy dynamic symbol resolution.
+# Use -z,lazy to override -z,now from SECURITY_LDFLAGS while keeping other hardening flags.
 LDFLAGS += "-Wl,-z,lazy"
 GO_LINKSHARED = ""
 


### PR DESCRIPTION
## Summary
- Remove `SECURITY_LDFLAGS = ""` override from libnvidia-container and nvidia-container-toolkit recipes
- Keep `-Wl,-z,lazy` which is required by go-nvml and overrides only `-z,now`, preserving partial RELRO and other hardening flags
- Fixes GHSA-42wv-fj86-jvm8

## Test plan
- [x] Verified both `bitbake libnvidia-container` and `bitbake nvidia-container-toolkit` build successfully