### PR TITLE
recipes: use nobranch=1 for upstream git sources

### DIFF
--- a/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf_git.bb
+++ b/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf_git.bb
@@ -19,7 +19,7 @@ PACKAGECONFIG[tpm] = "-D TPM_ENABLE=TRUE,-D TPM_ENABLE=FALSE,,"
 #see https://src.fedoraproject.org/rpms/edk2/blob/rawhide/f/0032-Basetools-turn-off-gcc12-warning.patch
 BUILD_CFLAGS += "-Wno-error=stringop-overflow"
 
-SRC_URI = "gitsm://github.com/tianocore/edk2.git;branch=master;protocol=https \
+SRC_URI = "gitsm://github.com/tianocore/edk2.git;nobranch=1;protocol=https \
            file://0001-Update-path-to-native-BaseTools.patch \
            file://0002-BaseTools-makefile-adjust-to-build-in-under-bitbake.patch \
            file://0003-Debug-prefix-map.patch \

--- a/meta-dstack/recipes-core/dstack-zfs/dstack-zfs_2.2.5.bb
+++ b/meta-dstack/recipes-core/dstack-zfs/dstack-zfs_2.2.5.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=7087caaf1dc8a2856585619f4a787faa"
 HOMEPAGE ="https://github.com/openzfs/zfs"
 
 SRCREV = "33174af15112ed5c53299da2d28e763b0163f428"
-SRC_URI = "git://github.com/openzfs/zfs;protocol=https;branch=zfs-2.2-release \
+SRC_URI = "git://github.com/openzfs/zfs;protocol=https;nobranch=1 \
            file://0001-Define-strndupa-if-it-does-not-exist.patch \
            file://aaf28a4630af60496c9d33db1d06a7d7d8983422.patch \
            file://0001-fs-tests-cmd-readmmap-Replace-uint_t-with-uint32_t.patch \


### PR DESCRIPTION
## Summary
- Replace `branch=master` with `nobranch=1` in OVMF recipe
- Replace `branch=zfs-2.2-release` with `nobranch=1` in ZFS recipe
- SRCREV is already pinned to specific commits, so branch names are unnecessary and can cause fetch failures if upstream rebases

## Test plan
- [ ] `bitbake dstack-ovmf` fetches and builds successfully
- [ ] `bitbake dstack-zfs` fetches and builds successfully