### PR TITLE
libnvidia-container: fix TLS verification for build-time downloads

### DIFF
--- a/meta-nvidia/recipes-graphics/libnvidia-container/libnvidia-container_1.00.bb
+++ b/meta-nvidia/recipes-graphics/libnvidia-container/libnvidia-container_1.00.bb
@@ -39,7 +39,8 @@ do_compile() {
     export SOURCE_DATE_EPOCH="${@d.getVar('SOURCE_DATE_EPOCH') or '0'}"
     export CGO_LDFLAGS="${CGO_LDFLAGS} -Wl,--build-id=none"
 
-    export CURL="curl --insecure"
+    # Point curl to the correct CA certificates in the native sysroot
+    export CURL_CA_BUNDLE="${RECIPE_SYSROOT_NATIVE}/etc/ssl/certs/ca-certificates.crt"
 
     oe_runmake
 }


### PR DESCRIPTION
## Summary

- Replace `curl --insecure` with proper CA certificate configuration using `CURL_CA_BUNDLE` pointing to the native sysroot certificates
- This fixes TLS verification for build-time downloads in libnvidia-container recipe

## Why

The previous approach disabled TLS verification entirely (`curl --insecure`), which is a security concern. Instead, we configure `CURL_CA_BUNDLE` to point to the CA certificates available in the native sysroot.

Split out from #42 to keep the k3s kernel module changes separate.