### PR TITLE
fix: upgrade OVMF to edk2-stable202505 tagged release

### DIFF
--- a/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf/0003-Debug-prefix-map.patch
+++ b/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf/0003-Debug-prefix-map.patch
@@ -1,17 +1,17 @@
-From aa8d288279ef96ffe576a0e434c1d9f435fef1e7 Mon Sep 17 00:00:00 2001
+From 672d571ed826157e15969b7ba0ec46ab622a7c44 Mon Sep 17 00:00:00 2001
 From: Kevin Wang <wy721@qq.com>
-Date: Mon, 4 Nov 2024 04:29:03 +0000
-Subject: [PATCH 3/5] Debug prefix map
+Date: Wed, 18 Mar 2026 08:44:20 +0000
+Subject: [PATCH] Debug prefix map
 
 ---
  BaseTools/Conf/tools_def.template | 18 +++++++++---------
  1 file changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/BaseTools/Conf/tools_def.template b/BaseTools/Conf/tools_def.template
-index 0f110fbb4a..35205db748 100755
+index cca699c4a8..e758bd8b4e 100755
 --- a/BaseTools/Conf/tools_def.template
 +++ b/BaseTools/Conf/tools_def.template
-@@ -896,7 +896,7 @@ NOOPT_*_*_OBJCOPY_ADDDEBUGFLAG     = --add-gnu-debuglink="$(DEBUG_DIR)/$(MODULE_
+@@ -920,7 +920,7 @@ NOOPT_*_*_OBJCOPY_ADDDEBUGFLAG     = --add-gnu-debuglink="$(DEBUG_DIR)/$(MODULE_
  *_*_*_DTC_PATH                     = DEF(DTC_BIN)
  
  # All supported GCC archs except LOONGARCH64 support -mstack-protector-guard=global, so set that on everything except LOONGARCH64
@@ -20,7 +20,7 @@ index 0f110fbb4a..35205db748 100755
  DEFINE GCC_IA32_X64_CC_FLAGS       = -mstack-protector-guard=global
  DEFINE GCC_ARM_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -mlittle-endian -mabi=aapcs -fno-short-enums -funsigned-char -ffunction-sections -fdata-sections -fomit-frame-pointer -Wno-address -mthumb -fno-pic -fno-pie -mstack-protector-guard=global
  DEFINE GCC_LOONGARCH64_CC_FLAGS    = DEF(GCC_ALL_CC_FLAGS) -mabi=lp64d -fno-asynchronous-unwind-tables -Wno-address -fno-short-enums -fsigned-char -ffunction-sections -fdata-sections
-@@ -918,8 +918,8 @@ DEFINE GCC_ARM_ASLDLINK_FLAGS      = DEF(GCC_ARM_DLINK_FLAGS) -Wl,--entry,Refere
+@@ -941,8 +941,8 @@ DEFINE GCC_ARM_ASLDLINK_FLAGS      = DEF(GCC_ARM_DLINK_FLAGS) -Wl,--entry,Refere
  DEFINE GCC_AARCH64_ASLDLINK_FLAGS  = DEF(GCC_AARCH64_DLINK_FLAGS) -Wl,--entry,ReferenceAcpiTable -u $(IMAGE_ENTRY_POINT) DEF(GCC_ARM_AARCH64_ASLDLINK_FLAGS)
  DEFINE GCC_LOONGARCH64_ASLDLINK_FLAGS = DEF(GCC_LOONGARCH64_DLINK_FLAGS) -Wl,--entry,ReferenceAcpiTable -u $(IMAGE_ENTRY_POINT)
  DEFINE GCC_IA32_X64_DLINK_FLAGS    = DEF(GCC_IA32_X64_DLINK_COMMON) --entry _$(IMAGE_ENTRY_POINT) --file-alignment 0x20 --section-alignment 0x20 -Map $(DEST_DIR_DEBUG)/$(BASE_NAME).map
@@ -28,10 +28,10 @@ index 0f110fbb4a..35205db748 100755
 -DEFINE GCC_PP_FLAGS                = -E -x assembler-with-cpp -include AutoGen.h
 +DEFINE GCC_ASM_FLAGS               = -c -x assembler -imacros AutoGen.h ENV(GCC_PREFIX_MAP)
 +DEFINE GCC_PP_FLAGS                = -E -x assembler-with-cpp -include AutoGen.h ENV(GCC_PREFIX_MAP)
- DEFINE GCC_VFRPP_FLAGS             = -x c -E -P -DVFRCOMPILE --include $(MODULE_NAME)StrDefs.h
+ DEFINE GCC_VFRPP_FLAGS             = -x c -E -DVFRCOMPILE --include $(MODULE_NAME)StrDefs.h
  DEFINE GCC_ASLPP_FLAGS             = -x c -E -include AutoGen.h
  DEFINE GCC_ASLCC_FLAGS             = -x c
-@@ -1072,7 +1072,7 @@ DEFINE GCC5_LOONGARCH64_PP_FLAGS           = -mabi=lp64d -march=loongarch64 DEF(
+@@ -1095,7 +1095,7 @@ DEFINE GCC5_LOONGARCH64_PP_FLAGS           = -mabi=lp64d -march=loongarch64 DEF(
  *_GCC48_IA32_DLINK2_FLAGS         = DEF(GCC48_IA32_DLINK2_FLAGS)
  *_GCC48_IA32_RC_FLAGS             = DEF(GCC_IA32_RC_FLAGS)
  *_GCC48_IA32_OBJCOPY_FLAGS        =
@@ -40,7 +40,7 @@ index 0f110fbb4a..35205db748 100755
  
    DEBUG_GCC48_IA32_CC_FLAGS       = DEF(GCC48_IA32_CC_FLAGS)
  RELEASE_GCC48_IA32_CC_FLAGS       = DEF(GCC48_IA32_CC_FLAGS) -Wno-unused-but-set-variable
-@@ -1100,7 +1100,7 @@ RELEASE_GCC48_IA32_CC_FLAGS       = DEF(GCC48_IA32_CC_FLAGS) -Wno-unused-but-set
+@@ -1123,7 +1123,7 @@ RELEASE_GCC48_IA32_CC_FLAGS       = DEF(GCC48_IA32_CC_FLAGS) -Wno-unused-but-set
  *_GCC48_X64_DLINK2_FLAGS         = DEF(GCC48_X64_DLINK2_FLAGS)
  *_GCC48_X64_RC_FLAGS             = DEF(GCC_X64_RC_FLAGS)
  *_GCC48_X64_OBJCOPY_FLAGS        =
@@ -49,7 +49,7 @@ index 0f110fbb4a..35205db748 100755
  
    DEBUG_GCC48_X64_CC_FLAGS       = DEF(GCC48_X64_CC_FLAGS)
  RELEASE_GCC48_X64_CC_FLAGS       = DEF(GCC48_X64_CC_FLAGS) -Wno-unused-but-set-variable
-@@ -1209,7 +1209,7 @@ RELEASE_GCC48_AARCH64_CC_FLAGS   = DEF(GCC48_AARCH64_CC_FLAGS) -Wno-unused-but-s
+@@ -1232,7 +1232,7 @@ RELEASE_GCC48_AARCH64_CC_FLAGS   = DEF(GCC48_AARCH64_CC_FLAGS) -Wno-unused-but-s
  *_GCC49_IA32_DLINK2_FLAGS         = DEF(GCC49_IA32_DLINK2_FLAGS)
  *_GCC49_IA32_RC_FLAGS             = DEF(GCC_IA32_RC_FLAGS)
  *_GCC49_IA32_OBJCOPY_FLAGS        =
@@ -58,7 +58,7 @@ index 0f110fbb4a..35205db748 100755
  
    DEBUG_GCC49_IA32_CC_FLAGS       = DEF(GCC49_IA32_CC_FLAGS)
  RELEASE_GCC49_IA32_CC_FLAGS       = DEF(GCC49_IA32_CC_FLAGS) -Wno-unused-but-set-variable -Wno-unused-const-variable
-@@ -1237,7 +1237,7 @@ RELEASE_GCC49_IA32_CC_FLAGS       = DEF(GCC49_IA32_CC_FLAGS) -Wno-unused-but-set
+@@ -1260,7 +1260,7 @@ RELEASE_GCC49_IA32_CC_FLAGS       = DEF(GCC49_IA32_CC_FLAGS) -Wno-unused-but-set
  *_GCC49_X64_DLINK2_FLAGS         = DEF(GCC49_X64_DLINK2_FLAGS)
  *_GCC49_X64_RC_FLAGS             = DEF(GCC_X64_RC_FLAGS)
  *_GCC49_X64_OBJCOPY_FLAGS        =
@@ -67,7 +67,7 @@ index 0f110fbb4a..35205db748 100755
  
    DEBUG_GCC49_X64_CC_FLAGS       = DEF(GCC49_X64_CC_FLAGS)
  RELEASE_GCC49_X64_CC_FLAGS       = DEF(GCC49_X64_CC_FLAGS) -Wno-unused-but-set-variable -Wno-unused-const-variable
-@@ -1496,7 +1496,7 @@ RELEASE_GCCNOLTO_AARCH64_DLINK_XIPFLAGS = -z common-page-size=0x20
+@@ -1519,7 +1519,7 @@ RELEASE_GCCNOLTO_AARCH64_DLINK_XIPFLAGS = -z common-page-size=0x20
  *_GCC5_IA32_DLINK2_FLAGS         = DEF(GCC5_IA32_DLINK2_FLAGS) -no-pie
  *_GCC5_IA32_RC_FLAGS             = DEF(GCC_IA32_RC_FLAGS)
  *_GCC5_IA32_OBJCOPY_FLAGS        =
@@ -76,7 +76,7 @@ index 0f110fbb4a..35205db748 100755
  
    DEBUG_GCC5_IA32_CC_FLAGS       = DEF(GCC5_IA32_CC_FLAGS) -flto
    DEBUG_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -flto -Os -Wl,-m,elf_i386,--oformat=elf32-i386
-@@ -1528,7 +1528,7 @@ RELEASE_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -flto -Os -Wl,
+@@ -1551,7 +1551,7 @@ RELEASE_GCC5_IA32_DLINK_FLAGS    = DEF(GCC5_IA32_X64_DLINK_FLAGS) -flto -Os -Wl,
  *_GCC5_X64_DLINK2_FLAGS          = DEF(GCC5_X64_DLINK2_FLAGS)
  *_GCC5_X64_RC_FLAGS              = DEF(GCC_X64_RC_FLAGS)
  *_GCC5_X64_OBJCOPY_FLAGS         =

--- a/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf/0004-Reproduciable.patch
+++ b/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf/0004-Reproduciable.patch
@@ -1,7 +1,7 @@
-From 81fc61513cf51a9ef6947dcf4bc1388a50c13f42 Mon Sep 17 00:00:00 2001
+From 9133327256392a17883ad3ed91ad63ecbac50f08 Mon Sep 17 00:00:00 2001
 From: Kevin Wang <wy721@qq.com>
-Date: Mon, 4 Nov 2024 04:29:41 +0000
-Subject: [PATCH 4/5] Reproduciable
+Date: Wed, 18 Mar 2026 08:44:21 +0000
+Subject: [PATCH] Reproduciable
 
 ---
  BaseTools/Source/C/GenFw/Elf64Convert.c       |  8 ++++---
@@ -11,19 +11,19 @@ Subject: [PATCH 4/5] Reproduciable
  4 files changed, 24 insertions(+), 16 deletions(-)
 
 diff --git a/BaseTools/Source/C/GenFw/Elf64Convert.c b/BaseTools/Source/C/GenFw/Elf64Convert.c
-index 9d04fc612e..83fd6c9c05 100644
+index 6919e18809..f6696ae805 100644
 --- a/BaseTools/Source/C/GenFw/Elf64Convert.c
 +++ b/BaseTools/Source/C/GenFw/Elf64Convert.c
-@@ -13,6 +13,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
- #ifndef __GNUC__
+@@ -15,6 +15,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
  #include <windows.h>
+ #undef RUNTIME_FUNCTION
  #include <io.h>
 +#else
 +#define _GNU_SOURCE
  #endif
  #include <assert.h>
  #include <stdio.h>
-@@ -988,7 +990,7 @@ ScanSections64 (
+@@ -990,7 +992,7 @@ ScanSections64 (
    }
    mCoffOffset = mDebugOffset + sizeof(EFI_IMAGE_DEBUG_DIRECTORY_ENTRY) +
                  sizeof(EFI_IMAGE_DEBUG_CODEVIEW_NB10_ENTRY) +
@@ -32,7 +32,7 @@ index 9d04fc612e..83fd6c9c05 100644
  
    //
    // Add more space in the .debug data region for the DllCharacteristicsEx
-@@ -2299,7 +2301,7 @@ WriteDebug64 (
+@@ -2310,7 +2312,7 @@ WriteDebug64 (
    EFI_IMAGE_DEBUG_CODEVIEW_NB10_ENTRY         *Nb10;
    EFI_IMAGE_DEBUG_EX_DLLCHARACTERISTICS_ENTRY *DllEntry;
  
@@ -41,7 +41,7 @@ index 9d04fc612e..83fd6c9c05 100644
  
    NtHdr = (EFI_IMAGE_OPTIONAL_HEADER_UNION *)(mCoffFile + mNtHdrOffset);
    DataDir = &NtHdr->Pe32Plus.OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_DEBUG];
-@@ -2332,7 +2334,7 @@ WriteDebug64 (
+@@ -2343,7 +2345,7 @@ WriteDebug64 (
  
    Nb10 = (EFI_IMAGE_DEBUG_CODEVIEW_NB10_ENTRY*)(Dir + 1);
    Nb10->Signature = CODEVIEW_SIGNATURE_NB10;
@@ -65,7 +65,7 @@ index 45b39d7878..3fed7d1736 100644
          if Input not in self.Inputs:
              self.Inputs.append(Input)
 diff --git a/BaseTools/Source/Python/AutoGen/GenMake.py b/BaseTools/Source/Python/AutoGen/GenMake.py
-index 6d9c60b702..83ac267647 100755
+index 547c708fc7..29859c4a0b 100755
 --- a/BaseTools/Source/Python/AutoGen/GenMake.py
 +++ b/BaseTools/Source/Python/AutoGen/GenMake.py
 @@ -576,7 +576,7 @@ cleanlib:
@@ -116,7 +116,7 @@ index 6d9c60b702..83ac267647 100755
                     }
  
          RespDict = {}
-@@ -1008,9 +1008,9 @@ cleanlib:
+@@ -1019,9 +1019,9 @@ cleanlib:
                  if not self.ObjTargetDict.get(T.Target.SubDir):
                      self.ObjTargetDict[T.Target.SubDir] = set()
                  self.ObjTargetDict[T.Target.SubDir].add(NewFile)

--- a/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf/0005-Declare-ProcessLibraryConstructorList.patch
+++ b/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf/0005-Declare-ProcessLibraryConstructorList.patch
@@ -1,6 +1,6 @@
-From 596f2e3bd7292c8f22cfe01ec95b8b46ce1bc8a1 Mon Sep 17 00:00:00 2001
+From 216280451e52ba73bc408e58c5a3b13d863e350f Mon Sep 17 00:00:00 2001
 From: Kevin Wang <wy721@qq.com>
-Date: Mon, 4 Nov 2024 04:35:18 +0000
+Date: Wed, 18 Mar 2026 08:44:21 +0000
 Subject: [PATCH] Declare ProcessLibraryConstructorList
 
 ---

--- a/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf_git.bb
+++ b/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf_git.bb
@@ -27,8 +27,8 @@ SRC_URI = "gitsm://github.com/tianocore/edk2.git;branch=master;protocol=https \
            file://0005-Declare-ProcessLibraryConstructorList.patch \
            "
 
-PV = "edk2-3a3b12cb"
-SRCREV = "3a3b12cbdae2e89b0e365eb01c378891d0d9037c"
+PV = "edk2-stable202505"
+SRCREV = "6951dfe7d59d144a3a980bd7eda699db2d8554ac"
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>edk2-stable.*)"
 
 CVE_PRODUCT = "edk2"


### PR DESCRIPTION
## Summary

- Upgrade OVMF from untagged master commit (`3a3b12cb`, 2024-09-20) to `edk2-stable202505` tagged release (`6951dfe7`)
- Refresh patches 0003-0005 to apply cleanly against the new base (context line offsets changed)

## Test plan

- [x] `bitbake dstack-ovmf` builds successfully with no patch-fuzz warnings
- [x] Full `build.sh guest` image build passes

Partially addresses #47