### PR TITLE
Replace small NTS servers with authoritative providers

### DIFF
--- a/meta-dstack/recipes-core/chrony/files/chrony.conf
+++ b/meta-dstack/recipes-core/chrony/files/chrony.conf
@@ -11,12 +11,12 @@ confdir /etc/chrony/conf.d
 # Use a local timeserver in preference to the pool, if it's reachable.
 #server 192.168.22.22 iburst minpoll 2 prefer
 server time.cloudflare.com iburst nts
-server nts.teambelgium.net iburst nts
-server a.st1.ntp.br iburst nts
-server time.bolha.one iburst nts
 server ptbtime1.ptb.de iburst nts
-server ntp2.glypnod.com iburst nts
-server ntp1.glypnod.com iburst nts
+server ptbtime2.ptb.de iburst nts
+server ptbtime3.ptb.de iburst nts
+server nts.netnod.se iburst nts
+server nts.ntp.se iburst nts
+server ntppool1.time.nl iburst nts
 server virginia.time.system76.com iburst nts
 
 # Sync to pulse-per-second from an onboard GPS.

--- a/meta-dstack/recipes-core/chrony/files/chrony.conf
+++ b/meta-dstack/recipes-core/chrony/files/chrony.conf
@@ -18,6 +18,8 @@ server nts.netnod.se iburst nts
 server nts.ntp.se iburst nts
 server ntppool1.time.nl iburst nts
 server virginia.time.system76.com iburst nts
+server oregon.time.system76.com iburst nts
+server paris.time.system76.com iburst nts
 
 # Sync to pulse-per-second from an onboard GPS.
 #refclock PPS /dev/pps0 poll 0 prefer


### PR DESCRIPTION
## Summary
- Remove community-run NTS servers (`ntp1/ntp2.glypnod.com`, `nts.teambelgium.net`, `a.st1.ntp.br`, `time.bolha.one`) that complained about excessive NTS-KE traffic from our fleet
- Replace with authoritative Stratum 1 NTS servers from major institutions:
  - **PTB** (German national metrology institute): `ptbtime2.ptb.de`, `ptbtime3.ptb.de`
  - **Netnod** (Swedish internet infrastructure): `nts.netnod.se`, `nts.ntp.se`
  - **SIDN Labs** (Dutch .nl registry): `ntppool1.time.nl`
- Keep existing `time.cloudflare.com`, `ptbtime1.ptb.de`, `virginia.time.system76.com`

All new servers have been tested and verified working with NTS-KE from our network.

## Test plan
- [x] Verified all new NTS servers respond correctly with TLS 1.3 NTS-KE handshake
- [x] Confirmed Stratum 1 sync from all PTB, Netnod, and SIDN servers
- [ ] Deploy to a test VM and confirm `chronyc authdata` shows NTS authentication for all sources