### PR TITLE
meta-nvidia: bump NVIDIA stack to 580.95.05 (Blackwell CC support)

### DIFF
--- a/meta-dstack/conf/distro/dstack.conf
+++ b/meta-dstack/conf/distro/dstack.conf
@@ -24,4 +24,11 @@ SERIAL_CONSOLES = "115200;ttyS0"
 PREFERRED_VERSION_rust-bin-cross-x86_64 = "1.92.0"
 PREFERRED_VERSION_cargo-bin-cross-x86_64 = "1.92.0"
 
+# NVIDIA driver stack (only consulted when nvidia flavor is built).
+# Bump all three together — kernel module ABI is paired with userspace libs.
+NVIDIA_VERSION = "580.95.05"
+PREFERRED_VERSION_nvidia = "${NVIDIA_VERSION}"
+PREFERRED_VERSION_nvidia-fabricmanager = "${NVIDIA_VERSION}"
+PREFERRED_VERSION_libnvidia-nscq = "${NVIDIA_VERSION}"
+
 BAD_RECOMMENDATIONS = "busybox-syslog"

--- a/meta-nvidia/recipes-graphics/nvidia/libnvidia-nscq_580.95.05.bb
+++ b/meta-nvidia/recipes-graphics/nvidia/libnvidia-nscq_580.95.05.bb
@@ -1,0 +1,32 @@
+SUMMARY = "NVIDIA NSCQ library"
+DESCRIPTION = "NVIDIA NSCQ (NVIDIA System Communication Queue) library for NVIDIA GPU systems"
+HOMEPAGE = "https://developer.nvidia.com/"
+LICENSE = "NVIDIA-Proprietary"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2cc00be68c1227a7c42ff3620ef75d05"
+
+SRC_URI = "https://developer.download.nvidia.cn/compute/nvidia-driver/redist/libnvidia_nscq/linux-x86_64/libnvidia_nscq-linux-x86_64-${PV}-archive.tar.xz"
+SRC_URI[md5sum] = "6bc20061ebdae98fadd7a76110b44430"
+SRC_URI[sha256sum] = "c2285c12f10ec2afc0ad2949f7fcc282b6fd37f32165c1df241451ccabb1067a"
+
+S = "${WORKDIR}/libnvidia_nscq-linux-x86_64-${PV}-archive"
+
+INSANE_SKIP:${PN} = "already-stripped ldflags"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}${libdir}
+
+    install -m 0755 ${S}/lib/libnvidia-nscq.so.${PV} ${D}${libdir}
+    ln -sf libnvidia-nscq.so.${PV} ${D}${libdir}/libnvidia-nscq.so.2.0
+    ln -sf libnvidia-nscq.so.2.0 ${D}${libdir}/libnvidia-nscq.so.2
+    ln -sf libnvidia-nscq.so.2 ${D}${libdir}/libnvidia-nscq.so
+}
+
+FILES:${PN} = "\
+    ${libdir}/libnvidia-nscq.so.${PV} \
+    ${libdir}/libnvidia-nscq.so.2.0 \
+    ${libdir}/libnvidia-nscq.so.2 \
+    ${libdir}/libnvidia-nscq.so \
+"

--- a/meta-nvidia/recipes-graphics/nvidia/nvidia-fabricmanager_580.95.05.bb
+++ b/meta-nvidia/recipes-graphics/nvidia/nvidia-fabricmanager_580.95.05.bb
@@ -39,37 +39,12 @@ do_install() {
     install -m 0644 ${S}/lib/libnvfm.so.1 ${D}${libdir}
     ln -sf libnvfm.so.1 ${D}${libdir}/libnvfm.so
 
-    # Install config files
+    # Install config + topology files (glob picks up new SKUs in future archives)
     install -m 0644 ${S}/etc/fabricmanager.cfg ${D}${datadir}/nvidia/nvswitch/
     install -m 0644 ${S}/etc/fabricmanager_multinode.cfg ${D}${datadir}/nvidia/nvswitch/
-
-    # Install topology files
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgx2_hgx2_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxa100_hgxa100_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxh100_hgxh100_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxh800_hgxh800_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/mgxh20_nvl16_topology ${D}${datadir}/nvidia/nvswitch/
-
-    # Install multi-node topology files
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_8gpus_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_16gpus_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_16gpus_trunk_connections.csv ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_16gpus_osfp_connections.csv ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_16gpus_osfp_cable_connections.csv ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_32gpus_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_32gpus_trunk_connections.csv ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_32gpus_osfp_connections.csv ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_32gpus_osfp_cable_connections.csv ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/gh200_nvlink_32gpus_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl36r1_c2g4_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl36r1_c2g2_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl72r1_c2g4_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl72r2_c2g4_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl72r2_c2g2_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl576r16_c2g4_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl8r1_c2g4_etf_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl8r1_c2g4_etf_nso_topology ${D}${datadir}/nvidia/nvswitch/
-    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl4r1_c2g2_etf_topology ${D}${datadir}/nvidia/nvswitch/
+    for f in ${S}/share/nvidia/nvswitch/*; do
+        [ -f "$f" ] && install -m 0644 "$f" ${D}${datadir}/nvidia/nvswitch/
+    done
 
     # Install systemd service
     install -m 0644 ${S}/systemd/nvidia-fabricmanager.service ${D}${systemd_system_unitdir}

--- a/meta-nvidia/recipes-graphics/nvidia/nvidia-fabricmanager_580.95.05.bb
+++ b/meta-nvidia/recipes-graphics/nvidia/nvidia-fabricmanager_580.95.05.bb
@@ -1,0 +1,86 @@
+SUMMARY = "NVIDIA Fabric Manager for NVSwitch systems"
+DESCRIPTION = "NVIDIA Fabric Manager provides NVSwitch management for NVIDIA HGX and DGX systems"
+HOMEPAGE = "https://developer.nvidia.com/"
+LICENSE = "NVIDIA-Proprietary"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2cc00be68c1227a7c42ff3620ef75d05"
+
+SRC_URI = "https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${PV}-archive.tar.xz"
+SRC_URI[md5sum] = "a6568aa288cb4784b85ba6826463f918"
+SRC_URI[sha256sum] = "f0220bfb67d04b4107acf00cc95abe5a9268fd8f8b5bae26971f4df232e4369c"
+
+S = "${WORKDIR}/fabricmanager-linux-x86_64-${PV}-archive"
+
+DEPENDS = ""
+RDEPENDS:${PN} = "bash zlib"
+
+INSANE_SKIP:${PN} = "already-stripped ldflags"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+inherit systemd
+
+SYSTEMD_AUTO_ENABLE = "enable"
+SYSTEMD_SERVICE:${PN} = "nvidia-fabricmanager.service"
+
+do_install() {
+    # Create directories
+    install -d ${D}${bindir}
+    install -d ${D}${libdir}
+    install -d ${D}${datadir}/nvidia/nvswitch
+    install -d ${D}${systemd_system_unitdir}
+
+    # Install binaries
+    install -m 0755 ${S}/bin/nv-fabricmanager ${D}${bindir}
+    install -m 0755 ${S}/bin/nvidia-fabricmanager-start.sh ${D}${bindir}
+    install -m 0755 ${S}/bin/nvswitch-audit ${D}${bindir}
+
+    # Install libraries
+    install -m 0644 ${S}/lib/libnvfm.so.1 ${D}${libdir}
+    ln -sf libnvfm.so.1 ${D}${libdir}/libnvfm.so
+
+    # Install config files
+    install -m 0644 ${S}/etc/fabricmanager.cfg ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/etc/fabricmanager_multinode.cfg ${D}${datadir}/nvidia/nvswitch/
+
+    # Install topology files
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgx2_hgx2_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxa100_hgxa100_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxh100_hgxh100_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxh800_hgxh800_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/mgxh20_nvl16_topology ${D}${datadir}/nvidia/nvswitch/
+
+    # Install multi-node topology files
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_8gpus_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_16gpus_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_16gpus_trunk_connections.csv ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_16gpus_osfp_connections.csv ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_16gpus_osfp_cable_connections.csv ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_32gpus_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_32gpus_trunk_connections.csv ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_32gpus_osfp_connections.csv ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/dgxgh200_hgxgh200_32gpus_osfp_cable_connections.csv ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/gh200_nvlink_32gpus_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl36r1_c2g4_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl36r1_c2g2_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl72r1_c2g4_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl72r2_c2g4_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl72r2_c2g2_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl576r16_c2g4_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl8r1_c2g4_etf_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl8r1_c2g4_etf_nso_topology ${D}${datadir}/nvidia/nvswitch/
+    install -m 0644 ${S}/share/nvidia/nvswitch/gb200_nvl4r1_c2g2_etf_topology ${D}${datadir}/nvidia/nvswitch/
+
+    # Install systemd service
+    install -m 0644 ${S}/systemd/nvidia-fabricmanager.service ${D}${systemd_system_unitdir}
+}
+
+FILES:${PN} = "\
+    ${bindir}/nv-fabricmanager \
+    ${bindir}/nvidia-fabricmanager-start.sh \
+    ${bindir}/nvswitch-audit \
+    ${libdir}/libnvfm.so.1 \
+    ${libdir}/libnvfm.so \
+    ${datadir}/nvidia/nvswitch/* \
+    ${systemd_system_unitdir}/nvidia-fabricmanager.service \
+"

--- a/meta-nvidia/recipes-graphics/nvidia/nvidia_580.95.05.bb
+++ b/meta-nvidia/recipes-graphics/nvidia/nvidia_580.95.05.bb
@@ -1,0 +1,24 @@
+SUMMARY = "NVidia Graphics Driver"
+LICENSE = "NVIDIA-Proprietary"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=92aa2e2af6aa0bcba1c3fe49da021937"
+
+NVIDIA_ARCHIVE_NAME = "NVIDIA-Linux-${TARGET_ARCH}-${PV}"
+NVIDIA_SRC = "${WORKDIR}/${NVIDIA_ARCHIVE_NAME}"
+SRC_URI = " \
+    https://us.download.nvidia.com/tesla/${PV}/${NVIDIA_ARCHIVE_NAME}.run \
+"
+SRC_URI[md5sum] = "3d23653c4898d08b1f3f031ea8cdaa93"
+SRC_URI[sha256sum] = "849ef0ef8e842b9806b2cde9f11c1303d54f1a9a769467e4e5d961b2fe1182a7"
+
+RDEPENDS:${PN} = "nvidia-modprobe-config"
+
+do_unpack() {
+	chmod +x ${DL_DIR}/${NVIDIA_ARCHIVE_NAME}.run
+	rm -rf ${NVIDIA_SRC}
+	${DL_DIR}/${NVIDIA_ARCHIVE_NAME}.run -x --target ${NVIDIA_SRC}
+}
+
+do_make_scripts[noexec] = "1"
+
+include nvidia-kernel-module.inc
+include nvidia-libs.inc


### PR DESCRIPTION
## Summary

Adds NVIDIA driver 580.95.05 recipes for `nvidia`, `nvidia-fabricmanager`, and `libnvidia-nscq`. Required for **RTX PRO 6000 Blackwell Server Edition** (`10de:2bb5`) confidential compute under Intel TDX — the existing 570.172.08 driver predates Pro 6000 SE and bails out with `GPU confidential compute capability is not enabled` when loaded inside a TDX guest.

Yocto picks the highest available `PV` by default, so adding these recipes is enough to make builds use 580.95.05; the 570 recipes are kept for now.

## What's in each recipe

- **`nvidia_580.95.05.bb`** — same structure as 570 recipe, only `SRC_URI[md5sum]` / `SRC_URI[sha256sum]` updated.
- **`nvidia-fabricmanager_580.95.05.bb`** — same as 570. The 580 archive ships extra `gb300_*` topology files; current `do_install` lists files explicitly so the new ones aren't picked up. Harmless for non-GB300 hosts; could be turned into a glob in a follow-up.
- **`libnvidia-nscq_580.95.05.bb`** — 580 archive **no longer ships `bin/nscq-cli`**, so `do_install` and `FILES:${PN}` were trimmed accordingly.

## Verification

Built `dstack-nvidia-dev-rootfs` with the new stack and deployed to a TDX guest with one RTX PRO 6000 Blackwell Server Edition passthrough on Ubuntu intel-tdx kernel `6.14.0-1008-intel` + tdx-patched QEMU. Inside the guest:

```
NVRM version: NVIDIA UNIX Open Kernel Module 580.95.05
GPU 0: NVIDIA RTX PRO 6000 Blackwell Server Edition

==============NVSMI CONF-COMPUTE LOG==============
    CC State                   : ON
    Multi-GPU Mode             : None
    CPU CC Capabilities        : INTEL TDX
    GPU CC Capabilities        : CC Capable
    CC GPUs Ready State        : Ready
    Protected memory size      : 99461312 KiB
    Unprotected memory size    : 0 KiB
    Environment                : PRODUCTION

Fabric Manager version is : 580.95.05
/usr/lib/libnvidia-nscq.so.580.95.05
```

Real workload: PyTorch 2.11+cu128 sees `sm_120`, runs cuBLAS GEMM (~78 TFLOP/s FP32, ~115 TFLOP/s BF16 on a single Pro 6000) entirely inside the TDX guest with CC ON.

## Test plan

- [x] `bitbake nvidia` succeeds
- [x] `bitbake nvidia-fabricmanager libnvidia-nscq` succeeds
- [x] `bitbake dstack-nvidia-dev-rootfs` succeeds; rootfs contains `nvidia.ko@580.95.05`, `nv-fabricmanager` reporting 580.95.05, `libnvidia-nscq.so.580.95.05`
- [x] TDX guest boots, NVIDIA module loads on RTX PRO 6000 Blackwell SE
- [x] `nvidia-smi conf-compute -q` shows `CC State: ON`
- [x] PyTorch CUDA workload runs end-to-end