### PR TITLE
kernel: disable DirtyFrag trigger modules

### DIFF
--- a/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg
+++ b/meta-dstack/recipes-kernel/linux/files/dstack-docker.cfg
@@ -26,7 +26,17 @@ CONFIG_BRIDGE_VLAN_FILTERING=y
 CONFIG_XFRM=y
 CONFIG_XFRM_USER=y
 CONFIG_XFRM_ALGO=y
-CONFIG_INET_ESP=y
+# Disable ESP transforms to mitigate DirtyFrag-style page-cache writes via esp4/esp6.
+# Keep XFRM userspace support available for non-ESP networking features, but do
+# not build the vulnerable ESP protocol handlers.
+CONFIG_INET_ESP=n
+CONFIG_INET6_ESP=n
+CONFIG_XFRM_ESP=n
+
+# RxRPC is not needed by dstack and is another DirtyFrag trigger path. Keep it
+# disabled even if future kernel feature sets would otherwise enable it.
+CONFIG_AF_RXRPC=n
+CONFIG_RXKAD=n
 CONFIG_NETFILTER_XT_MATCH_BPF=y
 CONFIG_CRYPTO_SEQIV=y
 CONFIG_IPVLAN=m


### PR DESCRIPTION
## Summary
- disable IPv4/IPv6 ESP transforms in the dstack kernel config to remove the ESP DirtyFrag trigger path
- explicitly keep AF_RXRPC/RXKAD disabled so the RxRPC trigger path cannot be enabled by future feature sets
- keep generic XFRM userspace support enabled for non-ESP networking use cases

## Validation
- ran `git diff --check`
- inspected generated config fragments; ESP/RxRPC are disabled via `dstack-docker.cfg`

Note: this is a mitigation by removing the vulnerable protocol handlers from the built kernel rather than relying on module blacklisting, since ESP is currently built in.