### PR TITLE
rootfs: include nftables userspace

### DIFF
--- a/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
+++ b/meta-dstack/recipes-core/images/dstack-rootfs-base.inc
@@ -10,6 +10,7 @@ IMAGE_INSTALL = "\
     systemd \
     netbase \
     iptables \
+    nftables \
     docker-moby \
     docker-compose \
     tdx-guest-ko \


### PR DESCRIPTION
## Summary
- add the `nftables` package to the base rootfs so the `nft` userspace tool is available
- complements the existing nftables kernel module packaging already present in the image

## Validation
- ran `git diff --check`
- checked a running agent: `nf_tables.ko` can load, but `nft` was missing before this change