### PR TITLE
Fix tar option-injection in mk-image-mr helper

### DIFF
--- a/scripts/bin/mk-image-mr.sh
+++ b/scripts/bin/mk-image-mr.sh
@@ -99,7 +99,7 @@ echo "Creating final archive: $OUTPUT_FILE"
 
 # Change to the flattened directory and create archive without directory structure
 cd "$FLATTEN_DIR"
-tar -czf "../$OUTPUT_FILE" *
+tar -czf "../$OUTPUT_FILE" -- *
 cd - >/dev/null
 
 # Move the final file to the current working directory


### PR DESCRIPTION
### Motivation
- Prevent tar option-injection when re-archiving flattened files from potentially untrusted downloaded or local archives, which could allow attacker-controlled filenames beginning with `-` to be interpreted as tar options and lead to command execution.

### Description
- Add the end-of-options marker to the final tar invocation in `scripts/bin/mk-image-mr.sh` by changing `tar -czf "../$OUTPUT_FILE" *` to `tar -czf "../$OUTPUT_FILE" -- *` so dash-prefixed filenames are treated as data.

### Testing
- Ran `bash -n scripts/bin/mk-image-mr.sh` for a syntax check and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda45ae2b88327bf091f0e20dee7ca)