### PR TITLE
ci: harden build-guest manual release workflow

### DIFF
--- a/.github/workflows/build-guest.yml
+++ b/.github/workflows/build-guest.yml
@@ -13,6 +13,8 @@ jobs:
   build:
     runs-on: yocto-builder
     timeout-minutes: 480
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,8 +33,33 @@ jobs:
             repro-build/dist/reproduce.sh
           retention-days: 30
 
+  release:
+    if: inputs.tag != '' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    needs: build
+    runs-on: yocto-builder
+    timeout-minutes: 60
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: guest-images
+          path: repro-build/dist
+
+      - name: Validate release tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$'
+
       - name: Create tag and release
-        if: inputs.tag != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.tag }}


### PR DESCRIPTION
### Motivation
- The manual `build-guest` workflow could be dispatched against an arbitrary branch/ref and would tag and publish releases from that unreviewed ref, creating a supply-chain authorization risk. 
- The change aims to prevent unreviewed refs from producing official release artifacts while preserving the ability to run build-only workflows.

### Description
- Split release operations into a dedicated `release` job that runs only when a non-empty `tag` is provided and the workflow is dispatched from the repository default branch. 
- Added `environment: release` to require environment approval for releases and limited job permissions so the `build` job has `contents: read` and the `release` job has `contents: write`. 
- Explicitly check out the repository default branch in the `release` job and download artifacts produced by the `build` job. 
- Validate the supplied `tag` with a strict version-like regex before creating and pushing the tag and publishing the release.

### Testing
- Inspected the modified workflow with `git diff -- .github/workflows/build-guest.yml` to verify the intended changes were applied successfully. 
- Attempted to run `actionlint .github/workflows/build-guest.yml` but `actionlint` was not installed in the environment, so static linting was not executed. 
- Printed the updated workflow file to confirm the job gates, permissions, checkout ref, artifact download, and tag validation steps are present and syntactically correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda13f98708327bc9825605d105c3d)