### PR TITLE
ovmf: pin to edk2-stable202502 to fix RTMR0 mismatch on CVMs with memory > 2G

### DIFF
--- a/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf/0003-Debug-prefix-map.patch
+++ b/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf/0003-Debug-prefix-map.patch
@@ -28,7 +28,7 @@ index cca699c4a8..e758bd8b4e 100755
 -DEFINE GCC_PP_FLAGS                = -E -x assembler-with-cpp -include AutoGen.h
 +DEFINE GCC_ASM_FLAGS               = -c -x assembler -imacros AutoGen.h ENV(GCC_PREFIX_MAP)
 +DEFINE GCC_PP_FLAGS                = -E -x assembler-with-cpp -include AutoGen.h ENV(GCC_PREFIX_MAP)
- DEFINE GCC_VFRPP_FLAGS             = -x c -E -DVFRCOMPILE --include $(MODULE_NAME)StrDefs.h
+ DEFINE GCC_VFRPP_FLAGS             = -x c -E -P -DVFRCOMPILE --include $(MODULE_NAME)StrDefs.h
  DEFINE GCC_ASLPP_FLAGS             = -x c -E -include AutoGen.h
  DEFINE GCC_ASLCC_FLAGS             = -x c
 @@ -1095,7 +1095,7 @@ DEFINE GCC5_LOONGARCH64_PP_FLAGS           = -mabi=lp64d -march=loongarch64 DEF(

--- a/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf_git.bb
+++ b/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf_git.bb
@@ -27,9 +27,30 @@ SRC_URI = "gitsm://github.com/tianocore/edk2.git;branch=master;protocol=https \
            file://0005-Declare-ProcessLibraryConstructorList.patch \
            "
 
-PV = "edk2-stable202505"
-SRCREV = "6951dfe7d59d144a3a980bd7eda699db2d8554ac"
+# Pinned to edk2-stable202502 (Feb 2025) instead of the latest stable202505.
+# Between these two tags, six commits land in OvmfPkg / MdeModulePkg that
+# rewrite the boot-time RTMR[0] event chain:
+#   fb56dc78ef  QemuFwCfgLib: cache + measurement (adds fw_cfg BootMenu, bootorder)
+#   45a56d7505  OvmfPkg: add BootManagerMenuApp to dependencies
+#   9d9e3a2ba8  OvmfPkg: use BootManagerMenuApp as BootManagerMenu (Boot0000 hash changes)
+#   d433b4c8e4  PlatformBootManagerLib: register UiApp as optional boot option (new Boot0001)
+#   dd5cce3e53  PlatformBootManagerCommonLib: set UiApp as an optional boot option
+#   cd76265f1a  OvmfPkg: Enable Smbios measurement (adds EV_EFI_HANDOFF_TABLES whose
+#               digest is sha384(filtered QEMU SMBIOS table) — varies with -m / -cpu /
+#               -smbios type=1 and so cannot be precomputed from VmConfig alone)
+# stable202502 contains none of them and so produces the same 13-event RTMR[0]
+# layout as the legacy 3a3b12cb snapshot dstack used pre-upgrade, while still
+# carrying 5 months of post-Sep-2024 EDK2 fixes (incl. CVEs).
+PV = "edk2-stable202502"
+SRCREV = "fbe0805b2091393406952e84724188f8c1941837"
 UPSTREAM_CHECK_GITTAGREGEX = "(?P<pver>edk2-stable.*)"
+
+# Tag identifying the OVMF boot-time RTMR[0] event layout this build produces.
+# Consumed by mkimage.sh to stamp `ovmf_variant` into the image metadata.json so
+# verifiers can pick the matching dstack-mr code path without parsing PV.
+# Keep this in sync with the OvmfVariant enum in dstack/dstack-types when
+# bumping PV.
+OVMF_VARIANT = "pre202505"
 
 CVE_PRODUCT = "edk2"
 CVE_VERSION = "${@d.getVar('PV').split('-')[1]}"

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -69,7 +69,7 @@ GIT_REVISION=$(git rev-parse HEAD 2>/dev/null || echo "<unknown>")
 # Lift the OVMF variant tag straight out of the dstack-ovmf recipe so verifiers
 # know which RTMR[0] event layout to expect. Required: the recipe must declare
 # OVMF_VARIANT alongside PV.
-OVMF_VARIANT=$(bitbake-getvar --value OVMF_VARIANT -r dstack-ovmf | tail -n1)
+OVMF_VARIANT=$(bitbake-getvar --value OVMF_VARIANT -r dstack-ovmf)
 if [ -z "$OVMF_VARIANT" ]; then
     echo "Error: dstack-ovmf recipe is missing OVMF_VARIANT" >&2
     exit 1

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -65,7 +65,17 @@ $Q cp $OVMF_FIRMWARE ${OUTPUT_DIR}/
 $Q cp $ROOTFS_IMAGE ${OUTPUT_DIR}/rootfs.img.verity
 
 GIT_REVISION=$(git rev-parse HEAD 2>/dev/null || echo "<unknown>")
-echo "Generating metadata.json to ${OUTPUT_DIR}/metadata.json"
+
+# Lift the OVMF variant tag straight out of the dstack-ovmf recipe so verifiers
+# know which RTMR[0] event layout to expect. Required: the recipe must declare
+# OVMF_VARIANT alongside PV.
+OVMF_VARIANT=$(bitbake-getvar --value OVMF_VARIANT -r dstack-ovmf | tail -n1)
+if [ -z "$OVMF_VARIANT" ]; then
+    echo "Error: dstack-ovmf recipe is missing OVMF_VARIANT" >&2
+    exit 1
+fi
+
+echo "Generating metadata.json to ${OUTPUT_DIR}/metadata.json (ovmf_variant=$OVMF_VARIANT)"
 
 KARG0="console=ttyS0 init=/init panic=1 net.ifnames=0 biosdevname=0"
 KARG1="mce=off oops=panic pci=noearly pci=nommconf random.trust_cpu=y random.trust_bootloader=n tsc=reliable no-kvmclock"
@@ -81,7 +91,8 @@ cat <<EOF > ${OUTPUT_DIR}/metadata.json
     "version": "$DSTACK_VERSION",
     "git_revision": "$GIT_REVISION",
     "shared_ro": true,
-    "is_dev": ${IS_DEV}
+    "is_dev": ${IS_DEV},
+    "ovmf_variant": "$OVMF_VARIANT"
 }
 EOF
 


### PR DESCRIPTION
## Summary

PR #50 upgraded OVMF from the 2024-09 snapshot `3a3b12cb` to `edk2-stable202505`. Between those two, EDK2 added six commits in `OvmfPkg` / `MdeModulePkg` that rewrite the boot-time RTMR[0] event chain dstack's verifier replays:

| Commit | Date | Effect on RTMR0 |
|---|---|---|
| `fb56dc78ef` | 2024-09-27 | QemuFwCfg measurement → new fw_cfg BootMenu + bootorder events |
| `45a56d7505` | 2025-01-29 | Add BootManagerMenuApp dependency |
| `9d9e3a2ba8` | 2025-01-29 | Use BootManagerMenuApp as `Boot0000` (changes its hash) |
| `d433b4c8e4` | 2025-01-29 | Register UiApp as `Boot0001` (new entry) |
| `dd5cce3e53` | 2025-03-04 | UiApp marked as optional boot option |
| `cd76265f1a` | 2025-04-10 | **Enable SmbiosMeasurementDxe** — adds `EV_EFI_HANDOFF_TABLES` whose digest is `sha384(filtered QEMU SMBIOS table)` |

dstack PR [#678](https://github.com/Dstack-TEE/dstack/pull/678) modelled the resulting 17-event layout in `dstack-mr` and worked for 2 GB CVMs, but `EV_EFI_HANDOFF_TABLES` was hardcoded to a digest captured from a 2 GB CVM. Memory sizes other than 2 GB produce different SMBIOS Type 16/17/19 fields → different digest → **`RTMR0 mismatch` on KMS verify for any CVM with memory ≠ 2 GB** (8 GB / 16 GB / 32 GB all broken).

In principle dstack-mr could replicate QEMU's SMBIOS table generation in Rust and re-hash with EDK2's filter (and ship `cpu_id` + `-smbios type=1` overrides in `VmConfig`), but it's a lot of code to chase Intel's TCG-PFP-v1.06 compliance commit — when the simpler fix is to stay on the EDK2 stable tag that predates the change.

## Fix

`edk2-stable202502` (Feb 2025) is the most recent stable tag still **before** all six of the layout-changing commits, while carrying ~5 months of post-2024-09 EDK2 fixes (incl. CVE patches). Switching to it gives us the legacy 13-event RTMR[0] layout that dstack-mr's `Pre202505` code path handles correctly across any memory size, with zero code changes in dstack itself.

Three files:

- **`meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf_git.bb`** — bump `PV` → `edk2-stable202502`, refresh `SRCREV`, add `OVMF_VARIANT = "pre202505"`.
- **`meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf/0003-Debug-prefix-map.patch`** — `GCC_VFRPP_FLAGS` context line gained `-P` in stable202505. Adapt the one context line so quilt applies cleanly against stable202502.
- **`mkimage.sh`** — read `OVMF_VARIANT` from the recipe via `bitbake-getvar` and stamp it into `metadata.json`. dstack-mr's verifier reads this field to pick the right event-layout path (`Pre202505` vs `Stable202505`) instead of guessing from image names.

## Test plan

- [x] `bitbake dstack-ovmf` rebuilds cleanly with the patched `0003-Debug-prefix-map.patch` against stable202502
- [x] `make dist` produces `dstack-0.5.11.tar.gz` with `metadata.json` carrying `"ovmf_variant": "pre202505"`
- [x] Deploy 8 GB / 2 vCPU CVM via `dstack-vmm` against `dstack-0.5.11`
- [x] KMS verify passes (`Boot Progress: done`, no `RTMR0 mismatch` in `dstack-prepare.sh` logs)
- [x] Live quote RTMR0 = `dstack-mr measure` prediction byte-for-byte (`5bba6288696c9369311fe673001f386b8494ad8d9fbb918b8571eaf73ededa420c2e51f4fe3118556f8afbc1412ff1b6`, 13 events on RTMR[0])

## Future OVMF upgrades

Every stable tag from 202505 through 202605 (and `master`) still includes `cd76265f1a`; no upstream PCD switch exists to disable the SMBIOS measurement. When the next CVE forces an upgrade past stable202502, options are:

  1. Carry a local revert of the `SmbiosMeasurementDxe.inf` line in `OvmfPkg/IntelTdx/IntelTdxX64.{dsc,fdf}` (≈10 lines). 13- or 16-event layout depending on whether the BootManagerMenuApp + fw_cfg changes are reverted too.
  2. Replicate QEMU's SMBIOS generation in Rust + add `cpu_id` / `-smbios` fields to `VmConfig`.
  3. Push upstream EDK2 for a build-time PCD to gate SMBIOS measurement.

Option 1 is the most pragmatic and is left as a follow-up.