### PR TITLE
kernel: enable gVNIC (gve) + virtio-net for GCP C3; bump dstack

### DIFF
--- a/meta-dstack/recipes-kernel/linux/files/dstack.cfg
+++ b/meta-dstack/recipes-kernel/linux/files/dstack.cfg
@@ -8,6 +8,13 @@ CONFIG_9P_FS_POSIX_ACL=y
 CONFIG_PCI=y
 CONFIG_TUN=m
 CONFIG_VIRTIO_PCI=y
+
+# Network NIC drivers. GCP C3/modern instances use gVNIC (the Google gve
+# driver); older/virtio instances use virtio-net. Without gve, a C3 CVM gets
+# no NIC -> no DHCP -> no network. Build both in.
+CONFIG_VIRTIO_NET=y
+CONFIG_NET_VENDOR_GOOGLE=y
+CONFIG_GVE=y
 CONFIG_ISO9660_FS=y
 CONFIG_WIREGUARD=y
 CONFIG_TMPFS_POSIX_ACL=y


### PR DESCRIPTION
## What

- Enable NIC drivers in the guest kernel config:
  - `CONFIG_GVE=y` + `CONFIG_NET_VENDOR_GOOGLE=y` — Google gVNIC, used by GCP C3 / modern instances.
  - `CONFIG_VIRTIO_NET=y` — kept for older / virtio instances.
- Bump the `dstack` submodule `8f86e43 → f1ba0a2` (top commit: *feat(dstack-util): mix gcp vTPM AK pubkey into instance_id*).

## Why

A GCP C3 CVM exposes its NIC via gVNIC. Without the `gve` driver built in, the VM gets no NIC → no DHCP → no network. Building both gve and virtio-net in keeps a single image working across GCP and virtio hosts.

## Note

The submodule bump also pulls in unrelated upstream commits (sca tool, dstack-cloud, dependency bumps) as a routine sync — not only the GCP change.

> Version bump (`DISTRO_VERSION`) is intentionally kept out of this PR.