### PR TITLE
machine: unified dstack confidential-guest machine (TDX + SEV in one image)

### DIFF
--- a/meta-dstack/conf/local.conf
+++ b/meta-dstack/conf/local.conf
@@ -36,7 +36,7 @@
 #MACHINE ?= "genericx86-64"
 #
 # This sets the default machine to be qemux86-64 if no other machine is selected:
-MACHINE ??= "tdx"
+MACHINE ??= "dstack"
 
 # These are some of the more commonly used values. Looking at the files in the
 # meta/conf/machine directory, or the conf/machine directory of any additional layers

--- a/meta-dstack/conf/machine/dstack.conf
+++ b/meta-dstack/conf/machine/dstack.conf
@@ -9,7 +9,7 @@
 #
 # The QEMU/tune boilerplate below mirrors the generic x86-64 confidential-guest
 # machines in meta-confidential-compute (tdx.conf / sev-snp.conf). It is kept
-# self-contained here so the dstack machine does not depend on those layer's
+# self-contained here so the dstack machine does not depend on that layer's
 # machine names.
 
 # from require conf/machine/include/qemu.inc
@@ -31,7 +31,10 @@ QB_CPU_KVM:x86 ?= "-cpu IvyBridge -machine q35,i8042=off"
 QB_CPU:x86-64 ?= "-cpu IvyBridge -machine q35,i8042=off"
 QB_CPU_KVM:x86-64 ?= "-cpu IvyBridge -machine q35,i8042=off"
 
-# Keep the extra spectre/SSB mitigations enabled for confidential guests.
+# runqemu (test boot) kernel cmdline only -- NOT the production image cmdline,
+# which is built in mkimage.sh. Inherited verbatim from the tdx machine: it
+# turns the Spectre v2 mitigation off (nospectre_v2) for speed while keeping
+# the Speculative Store Bypass mitigation on (spec_store_bypass_disable=on).
 QB_KERNEL_CMDLINE_APPEND = "oprofile.timer=1 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 nospectre_v2 spec_store_bypass_disable=on"
 QB_OPT_APPEND = "-usb -device usb-tablet -usb -device usb-kbd"
 

--- a/meta-dstack/conf/machine/dstack.conf
+++ b/meta-dstack/conf/machine/dstack.conf
@@ -31,11 +31,10 @@ QB_CPU_KVM:x86 ?= "-cpu IvyBridge -machine q35,i8042=off"
 QB_CPU:x86-64 ?= "-cpu IvyBridge -machine q35,i8042=off"
 QB_CPU_KVM:x86-64 ?= "-cpu IvyBridge -machine q35,i8042=off"
 
-# runqemu (test boot) kernel cmdline only -- NOT the production image cmdline,
-# which is built in mkimage.sh. Inherited verbatim from the tdx machine: it
-# turns the Spectre v2 mitigation off (nospectre_v2) for speed while keeping
-# the Speculative Store Bypass mitigation on (spec_store_bypass_disable=on).
-QB_KERNEL_CMDLINE_APPEND = "oprofile.timer=1 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 nospectre_v2 spec_store_bypass_disable=on"
+# No QB_KERNEL_CMDLINE_APPEND: that only affects `runqemu` test boots, not the
+# production image cmdline (built in mkimage.sh). The tdx machine inherited one
+# that disabled the Spectre v2 mitigation (nospectre_v2); dropping it keeps test
+# boots at the kernel's default mitigations, matching production.
 QB_OPT_APPEND = "-usb -device usb-tablet -usb -device usb-kbd"
 
 DEFAULTTUNE ?= "x86-64-v3"

--- a/meta-dstack/conf/machine/dstack.conf
+++ b/meta-dstack/conf/machine/dstack.conf
@@ -1,0 +1,51 @@
+#@TYPE: Machine
+#@NAME: dstack confidential guest
+#@DESCRIPTION: Unified dstack confidential-guest machine. A single image that
+#              boots on both Intel TDX and AMD SEV-SNP hosts; the kernel
+#              detects the platform at runtime. Kernel feature fragments
+#              (tdx.scc / sev-snp.scc / ...) are reused from
+#              meta-confidential-compute via KERNEL_FEATURES in the
+#              linux-yocto bbappend.
+#
+# The QEMU/tune boilerplate below mirrors the generic x86-64 confidential-guest
+# machines in meta-confidential-compute (tdx.conf / sev-snp.conf). It is kept
+# self-contained here so the dstack machine does not depend on those layer's
+# machine names.
+
+# from require conf/machine/include/qemu.inc
+# Don't include kernels in standard images
+RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
+
+# Use a common kernel recipe for all QEMU machines
+PREFERRED_PROVIDER_virtual/kernel ??= "linux-yocto-tiny"
+
+EXTRA_IMAGEDEPENDS += "qemu-system-native qemu-helper-native:do_addto_recipe_sysroot"
+
+# from require conf/machine/include/x86/qemuboot-x86.inc
+# For runqemu
+IMAGE_CLASSES += "qemuboot"
+QB_SMP ?= "-smp 4"
+QB_CPU:x86 ?= "-cpu IvyBridge -machine q35,i8042=off"
+QB_CPU_KVM:x86 ?= "-cpu IvyBridge -machine q35,i8042=off"
+
+QB_CPU:x86-64 ?= "-cpu IvyBridge -machine q35,i8042=off"
+QB_CPU_KVM:x86-64 ?= "-cpu IvyBridge -machine q35,i8042=off"
+
+# Keep the extra spectre/SSB mitigations enabled for confidential guests.
+QB_KERNEL_CMDLINE_APPEND = "oprofile.timer=1 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 nospectre_v2 spec_store_bypass_disable=on"
+QB_OPT_APPEND = "-usb -device usb-tablet -usb -device usb-kbd"
+
+DEFAULTTUNE ?= "x86-64-v3"
+
+require conf/machine/include/x86/tune-x86-64-v3.inc
+
+KERNEL_IMAGETYPE = "bzImage"
+
+SERIAL_CONSOLES ?= "115200;ttyS0 115200;ttyS1"
+
+MACHINE_FEATURES += "x86 pci tpm2"
+
+do_image_wic[depends] += "syslinux:do_populate_sysroot syslinux-native:do_populate_sysroot mtools-native:do_populate_sysroot dosfstools-native:do_populate_sysroot"
+
+# For runqemu
+QB_SYSTEM_NAME = "dstack"

--- a/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
+++ b/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
@@ -49,6 +49,12 @@ KERNEL_FEATURES:append:dstack = " features/scsi/disk.scc \
                                   disk-encryption.scc \
                                   dstack-tdx.scc"
 
+# disk-encryption.scc (above, from meta-confidential-compute) ships dm-crypt
+# for the encrypted data volume but explicitly turns CONFIG_DM_VERITY off. The
+# dstack rootfs is dm-verity, so re-enable it here -- this is the last dm-verity
+# fragment in KERNEL_FEATURES for the dstack machine, so it wins the merge.
+KERNEL_FEATURES:append:dstack = " ${@bb.utils.contains("DISTRO_FEATURES", "dm-verity", " features/device-mapper/dm-verity.scc", "", d)}"
+
 # Enable BTF
 KERNEL_DEBUG = "True"
 

--- a/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
+++ b/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
@@ -36,7 +36,7 @@ KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "dm-verity", 
 # fragments are reused from meta-confidential-compute; enabling both TDX and
 # SEV here is what makes one image work on either platform.
 KMACHINE:dstack ?= "common-pc-64"
-COMPATIBLE_MACHINE:dstack = "dstack"
+COMPATIBLE_MACHINE:dstack = "^dstack$"
 KERNEL_FEATURES:append:dstack = " features/scsi/disk.scc \
                                   cfg/virtio.scc \
                                   cfg/paravirt_kvm.scc \

--- a/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
+++ b/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
@@ -14,8 +14,9 @@ SRC_URI += "file://dstack-docker.cfg \
 # TDX guests need DMA_DIRECT_REMAP for shared (decrypted) coherent DMA so
 # devices like NVMe can complete I/O. INTEL_TDX_GUEST does not select it
 # upstream (and the symbol is promptless, so a .cfg fragment cannot set it),
-# hence this Kconfig patch. Scoped to tdx machines only.
-SRC_URI:append:tdx = " file://0001-x86-tdx-select-dma-direct-remap.patch"
+# hence this Kconfig patch. Only touches the INTEL_TDX_GUEST Kconfig, so it is
+# a no-op on AMD; scoped to the dstack confidential-guest machine.
+SRC_URI:append:dstack = " file://0001-x86-tdx-select-dma-direct-remap.patch"
 
 KERNEL_FEATURES:append = " features/cgroups/cgroups.scc \
                           features/overlayfs/overlayfs.scc \
@@ -29,7 +30,24 @@ KERNEL_FEATURES:append = " features/cgroups/cgroups.scc \
 
 KERNEL_FEATURES:append = " ${@bb.utils.contains("DISTRO_FEATURES", "dm-verity", " features/device-mapper/dm-verity.scc", "" ,d)}"
 
-KERNEL_FEATURES:append:tdx = " dstack-tdx.scc"
+# Unified dstack confidential-guest machine. A single kernel image that boots
+# on both Intel TDX and AMD SEV-SNP hosts (the kernel detects the platform at
+# runtime). The base guest features and the tdx.scc / sev-snp.scc kconf
+# fragments are reused from meta-confidential-compute; enabling both TDX and
+# SEV here is what makes one image work on either platform.
+KMACHINE:dstack ?= "common-pc-64"
+COMPATIBLE_MACHINE:dstack = "dstack"
+KERNEL_FEATURES:append:dstack = " features/scsi/disk.scc \
+                                  cfg/virtio.scc \
+                                  cfg/paravirt_kvm.scc \
+                                  cfg/fs/ext4.scc \
+                                  tdx.scc \
+                                  sev-snp.scc \
+                                  tpm2.scc \
+                                  hyperv.scc \
+                                  security-mitigations.scc \
+                                  disk-encryption.scc \
+                                  dstack-tdx.scc"
 
 # Enable BTF
 KERNEL_DEBUG = "True"

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -50,9 +50,12 @@ fi
 BB_BUILD_DIR=$(realpath ${BB_BUILD_DIR:-build})
 DIST_DIR=$(realpath ${DIST_DIR:-${BB_BUILD_DIR}/dist})
 
+# MACHINE name; artifacts are deployed under deploy/images/${MACHINE}
+DSTACK_MACHINE=${DSTACK_MACHINE:-dstack}
+
 # Common artifacts are in tmp/, flavor-specific artifacts are in tmp-mc-<flavor>/
-COMMON_IMG_DIR=${BB_BUILD_DIR}/tmp/deploy/images/tdx
-FLAVOR_IMG_DIR=${BB_BUILD_DIR}/tmp-mc-${FLAVOR}/deploy/images/tdx
+COMMON_IMG_DIR=${BB_BUILD_DIR}/tmp/deploy/images/${DSTACK_MACHINE}
+FLAVOR_IMG_DIR=${BB_BUILD_DIR}/tmp-mc-${FLAVOR}/deploy/images/${DSTACK_MACHINE}
 
 # Common artifacts (shared across all flavors)
 INITRAMFS_IMAGE=${COMMON_IMG_DIR}/dstack-initramfs.cpio.gz
@@ -60,13 +63,13 @@ KERNEL_IMAGE=${COMMON_IMG_DIR}/bzImage
 OVMF_FIRMWARE=${COMMON_IMG_DIR}/ovmf.fd
 
 # Flavor-specific artifacts (from multiconfig build)
-ROOTFS_IMAGE=${FLAVOR_IMG_DIR}/dstack-rootfs-tdx.squashfs.verity
+ROOTFS_IMAGE=${FLAVOR_IMG_DIR}/dstack-rootfs-${DSTACK_MACHINE}.squashfs.verity
 
 # UKI filename
 UKI_IMAGE=${FLAVOR_IMG_DIR}/dstack-uki.efi
 
 # Verity env is in the flavor-specific work-shared directory
-VERITY_ENV_FILE=${BB_BUILD_DIR}/tmp-mc-${FLAVOR}/work-shared/tdx/dm-verity/dstack-rootfs.squashfs.verity.env
+VERITY_ENV_FILE=${BB_BUILD_DIR}/tmp-mc-${FLAVOR}/work-shared/${DSTACK_MACHINE}/dm-verity/dstack-rootfs.squashfs.verity.env
 if [ ! -f "${VERITY_ENV_FILE}" ]; then
     echo "Error: verity env not found: ${VERITY_ENV_FILE}" >&2
     echo "Build the rootfs first, e.g.: bitbake mc:${FLAVOR}:dstack-rootfs" >&2

--- a/repro-build/check.sh
+++ b/repro-build/check.sh
@@ -15,7 +15,7 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 IMAGE_NAME=${IMAGE_NAME:-dstack-rootfs}
-ROOTFS_PATH=tmp/work/tdx-poky-linux/${IMAGE_NAME}/1.0/rootfs
+ROOTFS_PATH=tmp/work/${DSTACK_MACHINE:-dstack}-poky-linux/${IMAGE_NAME}/1.0/rootfs
 BUILD_DIR_A=${1:-${THIS_DIR}/build-a}
 BUILD_DIR_B=${2:-${THIS_DIR}/build-b}
 BB_DIR_A=${BB_DIR_A:-${BUILD_DIR_A}/bb-build}

--- a/scripts/docker-check-config.sh
+++ b/scripts/docker-check-config.sh
@@ -17,7 +17,7 @@ possibleConfigs="
 if [ $# -gt 0 ]; then
 	CONFIG="$1"
 else
-	: "${CONFIG:=$SCRIPT_DIR/../bb-build/tmp/deploy/images/tdx/kernel-config}"
+	: "${CONFIG:=$SCRIPT_DIR/../bb-build/tmp/deploy/images/${DSTACK_MACHINE:-dstack}/kernel-config}"
 fi
 
 if ! command -v zgrep > /dev/null 2>&1; then


### PR DESCRIPTION
## What

Replace the TDX-specific `tdx` MACHINE with a single **`dstack`** machine that produces **one image bootable on both Intel TDX and AMD SEV-SNP hosts**. The kernel detects the confidential-computing platform at runtime (`cc_platform_has`), so there is no need to maintain separate per-technology images.

## Why one image works

TDX and SEV guest support are not mutually exclusive in the kernel — distro cloud kernels (Ubuntu/Fedora/Azure/GCP) all ship a single kernel that boots on both. We just enable both feature sets:

- `CONFIG_INTEL_TDX_GUEST=y` + `CONFIG_TDX_GUEST_DRIVER=y`
- `CONFIG_AMD_MEM_ENCRYPT=y` + `CONFIG_SEV_GUEST=y`

(`CONFIG_X86_DISABLED_FEATURE_SEV_SNP=y` remains — it is gated by `!KVM_AMD_SEV`, i.e. the *host/KVM* side, and is irrelevant to a guest image; identical to a standalone sev-snp build.)

## Changes

- **Add `meta-dstack/conf/machine/dstack.conf`** — self-contained x86-64 confidential-guest machine. Kernel feature fragments (`tdx.scc`, `sev-snp.scc`, `tpm2.scc`, …) are *reused* from `meta-confidential-compute` via `KERNEL_FEATURES` (referenced, not copied) — the submodule is left untouched.
- **`linux-yocto%.bbappend`** — wire `COMPATIBLE_MACHINE`/`KMACHINE`/`KERNEL_FEATURES` for `dstack` (enabling both `tdx.scc` and `sev-snp.scc`); move the `dma-direct-remap` patch override from `:tdx` to `:dstack`.
- **`local.conf`** — default `MACHINE = dstack`.
- **`mkimage.sh`** — derive `deploy/images/` and rootfs/verity paths from `${DSTACK_MACHINE}` (`dstack`).

The generic `tdx` and `sev-snp` machines in `meta-confidential-compute` are kept as-is for reuse by other projects.

## Verification

`bitbake virtual/kernel` (MACHINE=dstack) against **linux-yocto 6.18**:
- `do_compile: Succeeded`, full task chain (1070 tasks) succeeded
- `.config` confirmed: `INTEL_TDX_GUEST=y`, `AMD_MEM_ENCRYPT=y`, `SEV_GUEST=y`, `TDX_GUEST_DRIVER=y`, `X86_MEM_ENCRYPT=y`

## Note

Independent of #67 (ACPI BadAML sandbox). Both touch `linux-yocto%.bbappend` on non-overlapping lines, so they merge cleanly in either order.