### PR TITLE
dstack-ovmf: additionally build AMD SEV firmware (ovmf-sev.fd)

### DIFF
--- a/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf/0006-OvmfPkg-AmdSev-drop-embedded-grub.patch
+++ b/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf/0006-OvmfPkg-AmdSev-drop-embedded-grub.patch
@@ -1,0 +1,54 @@
+From: dstack <dstack@phala.network>
+Date: Mon, 16 Jun 2026 00:00:00 +0000
+Subject: [PATCH] OvmfPkg/AmdSev: drop the embedded sevsecret grub
+
+The AmdSevX64 firmware embeds a grub.efi (built by the OvmfPkg/AmdSev/Grub
+PREBUILD via grub-mkimage) that boots an encrypted LUKS volume using the
+SEV-injected secret and the out-of-tree sevsecret grub module.
+
+dstack does not use that boot model: it boots a UKI from an EFI System
+Partition with a dm-verity rootfs, so the embedded grub is dead weight.
+Building it is also infeasible here: OpenEmbedded provides no x86_64-efi
+grub modules at native build time and upstream grub has no sevsecret
+module (it is a distro patch).
+
+Remove the Grub PREBUILD and the Grub.inf component/FV entry. All other
+SEV / SEV-SNP functionality (SecretPei/SecretDxe secret injection, the
+BlobVerifierLibSevHashes kernel-hashes measured direct boot, SNP support)
+is unaffected.
+
+Upstream-Status: Inappropriate [dstack-specific firmware configuration]
+Signed-off-by: dstack <dstack@phala.network>
+---
+diff --git a/OvmfPkg/AmdSev/AmdSevX64.dsc b/OvmfPkg/AmdSev/AmdSevX64.dsc
+index e0eaa3c..76824d8 100644
+--- a/OvmfPkg/AmdSev/AmdSevX64.dsc
++++ b/OvmfPkg/AmdSev/AmdSevX64.dsc
+@@ -25,7 +25,6 @@
+   BUILD_TARGETS                  = NOOPT|DEBUG|RELEASE
+   SKUID_IDENTIFIER               = DEFAULT
+   FLASH_DEFINITION               = OvmfPkg/AmdSev/AmdSevX64.fdf
+-  PREBUILD                       = sh OvmfPkg/AmdSev/Grub/grub.sh
+ 
+   #
+   # Defines for default states.  These can be changed on the command line.
+@@ -731,7 +730,6 @@
+   MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassStorageDxe.inf
+ 
+   OvmfPkg/AmdSev/SecretDxe/SecretDxe.inf
+-  OvmfPkg/AmdSev/Grub/Grub.inf
+ 
+ !include OvmfPkg/Include/Dsc/ShellComponents.dsc.inc
+ !include OvmfPkg/Include/Dsc/OvmfRngComponents.dsc.inc
+diff --git a/OvmfPkg/AmdSev/AmdSevX64.fdf b/OvmfPkg/AmdSev/AmdSevX64.fdf
+index 4217870..ff727a5 100644
+--- a/OvmfPkg/AmdSev/AmdSevX64.fdf
++++ b/OvmfPkg/AmdSev/AmdSevX64.fdf
+@@ -283,7 +283,6 @@ INF  FatPkg/EnhancedFatDxe/Fat.inf
+ INF  MdeModulePkg/Universal/Disk/UdfDxe/UdfDxe.inf
+ 
+ INF OvmfPkg/AmdSev/SecretDxe/SecretDxe.inf
+-INF  OvmfPkg/AmdSev/Grub/Grub.inf
+ 
+ INF MdeModulePkg/Logo/LogoDxe.inf
+ 

--- a/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf_git.bb
+++ b/meta-dstack/recipes-core/dstack-ovmf/dstack-ovmf_git.bb
@@ -25,6 +25,7 @@ SRC_URI = "gitsm://github.com/tianocore/edk2.git;branch=master;protocol=https \
            file://0003-Debug-prefix-map.patch \
            file://0004-Reproduciable.patch \
            file://0005-UefiCpuPkg-CpuExceptionHandlerLib-fix-push-instructi.patch \
+           file://0006-OvmfPkg-AmdSev-drop-embedded-grub.patch \
            "
 
 # Pinned to edk2-stable202502 (Feb 2025) instead of the latest stable202505.
@@ -77,6 +78,16 @@ PARALLEL_MAKE = ""
 
 
 DEPENDS = "nasm-native acpica-native ovmf-native util-linux-native"
+
+# Build the AMD SEV firmware in addition to the Intel TDX one. The TDX build
+# (IntelTdxX64.dsc) and its carefully pinned measurement layout are left byte
+# for byte unchanged; this only adds a separate ovmf-sev.fd artifact. The
+# AmdSevX64 embedded grub (sevsecret LUKS boot) is removed via
+# 0006-OvmfPkg-AmdSev-drop-embedded-grub.patch -- dstack boots a UKI, not
+# grub, and that grub cannot be built here anyway (OE has no x86_64-efi grub
+# modules / no sevsecret). The patch fails loud if a future edk2 bump changes
+# the AmdSev layout.
+OVMF_BUILD_SEV ??= "1"
 
 EDK_TOOLS_DIR="edk2_basetools"
 
@@ -241,6 +252,18 @@ do_compile:class-target() {
         ln ${build_dir}/FV/OVMF_CODE.fd ${WORKDIR}/ovmf/ovmf.secboot.code.fd
         ln ${build_dir}/${OVMF_ARCH}/EnrollDefaultKeys.efi ${WORKDIR}/ovmf/
     fi
+
+    if [ "${OVMF_BUILD_SEV}" = "1" ]; then
+        # AMD SEV / SEV-SNP firmware. Additive: produces a single combined
+        # firmware blob (used via QEMU -bios) at ovmf-sev.fd, leaving the TDX
+        # build above untouched. The embedded grub is stripped below, so
+        # there is no PREBUILD / grub toolchain dependency.
+        bbnote "Building AMD SEV firmware (AmdSevX64.dsc)."
+        sev_build_dir="${S}/Build/AmdSev/RELEASE_${FIXED_GCCVER}"
+        rm -rf ${S}/Build/AmdSev
+        ${S}/OvmfPkg/build.sh -p ${S}/OvmfPkg/AmdSev/AmdSevX64.dsc $PARALLEL_JOBS -a $OVMF_ARCH -b RELEASE -t ${FIXED_GCCVER} ${PACKAGECONFIG_CONFARGS}
+        ln ${sev_build_dir}/FV/OVMF.fd ${WORKDIR}/ovmf/ovmf-sev.fd
+    fi
 }
 
 do_install:class-native() {
@@ -289,6 +312,12 @@ do_deploy:class-target() {
         cp ${WORKDIR}/ovmf/$i.fd ${DEPLOYDIR}/
         qemu-img convert -f raw -O qcow2 ${WORKDIR}/ovmf/$i.fd ${DEPLOYDIR}/$i.qcow2
     done
+
+    # AMD SEV firmware (single combined blob for QEMU -bios).
+    if [ "${OVMF_BUILD_SEV}" = "1" ] && [ -f ${WORKDIR}/ovmf/ovmf-sev.fd ]; then
+        cp ${WORKDIR}/ovmf/ovmf-sev.fd ${DEPLOYDIR}/
+        qemu-img convert -f raw -O qcow2 ${WORKDIR}/ovmf/ovmf-sev.fd ${DEPLOYDIR}/ovmf-sev.qcow2
+    fi
 
     if ${@bb.utils.contains('PACKAGECONFIG', 'secureboot', 'true', 'false', d)}; then
         # Create a test Platform Key and first Key Exchange Key to use with EnrollDefaultKeys

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -234,6 +234,17 @@ $Q cp $INITRAMFS_IMAGE ${OUTPUT_DIR}/initramfs.cpio.gz
 $Q cp $KERNEL_IMAGE ${OUTPUT_DIR}/
 $Q cp $OVMF_FIRMWARE ${OUTPUT_DIR}/
 
+# AMD SEV firmware (additive). Shipped alongside the TDX firmware so a SEV-SNP
+# launch can select it, but deliberately kept OUT of the image digest below:
+# sha256sum.txt / digest.txt / metadata.json stay TDX-only so the measured
+# image is byte-for-byte unchanged. SEV measurement is a separate concern.
+OVMF_SEV_FIRMWARE=${COMMON_IMG_DIR}/ovmf-sev.fd
+HAVE_OVMF_SEV=0
+if [ -f "$OVMF_SEV_FIRMWARE" ]; then
+    $Q cp $OVMF_SEV_FIRMWARE ${OUTPUT_DIR}/
+    HAVE_OVMF_SEV=1
+fi
+
 echo "Creating partitioned rootfs image at ${OUTPUT_DIR}/rootfs.img.parted.verity"
 # Bare-metal partitioning needs sgdisk (from the 'gdisk' package).
 if ! command -v sgdisk >/dev/null; then
@@ -308,6 +319,9 @@ if [ x$DSTACK_TAR_RELEASE = x1 ]; then
     rm -rf ${IMAGE_TAR}
     echo "Archiving bare metal image to ${IMAGE_TAR}"
     BARE_METAL_FILES="rootfs.img.parted.verity bzImage ovmf.fd digest.txt sha256sum.txt initramfs.cpio.gz metadata.json"
+    if [ "$HAVE_OVMF_SEV" = "1" ]; then
+        BARE_METAL_FILES="$BARE_METAL_FILES ovmf-sev.fd"
+    fi
     (cd "$PARENT_DIR" && tar -czvf ${IMAGE_TAR} $(for f in $BARE_METAL_FILES; do echo "$TAR_DIR_NAME/$f"; done))
     echo
 


### PR DESCRIPTION
## What

Build `OvmfPkg/AmdSev/AmdSevX64.dsc` in addition to the existing Intel TDX firmware, producing a separate **`ovmf-sev.fd`** for AMD SEV / SEV-SNP guests. Complements the unified TDX+SEV kernel image (#68) on the firmware side.

## TDX is untouched (measurement-safe)

The Intel TDX build (`IntelTdxX64.dsc`) and its carefully pinned RTMR[0] measurement layout (`edk2-stable202502` / `OVMF_VARIANT=pre202505`) are left **byte-for-byte unchanged**: the SEV firmware is built *after* the TDX one into a separate `Build/AmdSev` tree and deployed as a distinct artifact. `ovmf.fd` is bit-identical.

## Embedded grub removed

`AmdSevX64` embeds a grub (sevsecret + LUKS measured boot). dstack boots a **UKI with a dm-verity rootfs** and never uses it — and it can't be built here anyway: OE provides no `x86_64-efi` grub modules and upstream grub has no `sevsecret` module (it's a distro patch).

The grub `PREBUILD` and the `Grub.inf` component/FV entry are stripped in `do_compile` via `sed` (chosen over a patch file because EDK2 sources use CRLF, which made a unified-diff patch fail to apply). All other SEV/SEV-SNP functionality is retained: `SecretPei`/`SecretDxe` secret injection, the `BlobVerifierLibSevHashes` kernel-hashes measured direct boot, and SNP support.

## Changes

- `dstack-ovmf_git.bb` — `OVMF_BUILD_SEV` (default on); build AmdSevX64 additively; strip embedded grub; deploy `ovmf-sev.fd` (+ qcow2).
- `mkimage.sh` — ship `ovmf-sev.fd` alongside `ovmf.fd`, but keep it **out of the image digest** (`sha256sum.txt` / `digest.txt` / `metadata.json` stay TDX-only) so the measured TDX image is unchanged.

## Out of scope

SEV measurement / attestation (dstack-mr, the `bios` selection in metadata, VMM launch flow) — that lives in the dstack submodule and overlaps in-progress SEV-SNP work (PR #703).

## Verification

`bitbake dstack-ovmf`: `do_compile: Succeeded`, full task chain succeeded. Both `ovmf.fd` (TDX, 4 MiB) and `ovmf-sev.fd` (SEV, 4 MiB) deployed as distinct binaries (different sha256).

Independent of #67 and #68 (touches only the OVMF recipe + mkimage.sh).