### PR TITLE
mkimage: add bios-sev field to metadata.json for SEV firmware

### DIFF
--- a/mkimage.sh
+++ b/mkimage.sh
@@ -238,14 +238,20 @@ $Q cp $KERNEL_IMAGE ${OUTPUT_DIR}/
 $Q cp $OVMF_FIRMWARE ${OUTPUT_DIR}/
 
 # AMD SEV firmware (additive). Shipped alongside the TDX firmware so a SEV-SNP
-# launch can select it, but deliberately kept OUT of the image digest below:
-# sha256sum.txt / digest.txt / metadata.json stay TDX-only so the measured
-# image is byte-for-byte unchanged. SEV measurement is a separate concern.
+# launch can select it via the metadata.json "bios-sev" field below. The SEV
+# firmware blob itself is NOT added to sha256sum.txt, but metadata.json (which
+# references it) is, so digest.txt does reflect its presence. That does not
+# change any TDX hardware measurement (MRTD comes from ovmf.fd, RTMRs from
+# kernel/cmdline/rootfs) -- it only changes dstack's image-bundle digest.
 OVMF_SEV_FIRMWARE=${COMMON_IMG_DIR}/ovmf-sev.fd
 HAVE_OVMF_SEV=0
+BIOS_SEV_JSON=""
 if [ -f "$OVMF_SEV_FIRMWARE" ]; then
     $Q cp $OVMF_SEV_FIRMWARE ${OUTPUT_DIR}/
     HAVE_OVMF_SEV=1
+    # Inserted after the "bios" line in metadata.json (see below).
+    BIOS_SEV_JSON='
+    "bios-sev": "ovmf-sev.fd",'
 fi
 
 echo "Creating partitioned rootfs image at ${OUTPUT_DIR}/rootfs.img.parted.verity"
@@ -275,7 +281,7 @@ KARG2="dstack.rootfs_hash=$ROOT_HASH dstack.rootfs_size=$DATA_SIZE"
 
 cat <<EOF > ${OUTPUT_DIR}/metadata.json
 {
-    "bios": "ovmf.fd",
+    "bios": "ovmf.fd",${BIOS_SEV_JSON}
     "kernel": "bzImage",
     "cmdline": "$KARG0 $KARG1 $KARG2",
     "initrd": "initramfs.cpio.gz",


### PR DESCRIPTION
## What

Emit a `bios-sev` field in `metadata.json` pointing at `ovmf-sev.fd` when the AMD SEV firmware is present, alongside the existing TDX `"bios": "ovmf.fd"`:

```json
{
    "bios": "ovmf.fd",
    "bios-sev": "ovmf-sev.fd",
    "kernel": "bzImage",
    ...
}
```

This lets a VMM select the right firmware per platform (`ovmf.fd` on Intel TDX, `ovmf-sev.fd` on AMD SEV-SNP) from the image metadata instead of hardcoding the TDX firmware. Follow-up to #69 (which built/shipped `ovmf-sev.fd` but left it unreferenced in metadata).

## Behaviour

- The field is only emitted when `ovmf-sev.fd` was built/shipped (`OVMF_BUILD_SEV`), so non-SEV builds keep the original `metadata.json`.
- Both branches produce valid JSON (verified with `jq`).

## Measurement note

`metadata.json` is hashed into `sha256sum.txt`, so `digest.txt` (dstack's image-bundle digest) now reflects the `bios-sev` reference. This does **not** change any TDX hardware measurement: MRTD is measured from `ovmf.fd` and the RTMRs from kernel/cmdline/rootfs — none depend on `metadata.json`. Only the bundle digest changes, which is expected for a new image build.

## Not included

The VMM-side logic that *reads* `bios-sev` and selects it based on the detected platform lives in the dstack repo (overlaps the in-progress SEV-SNP work, PR #703) and is out of scope here.