### PR TITLE
mkimage: emit digest.sev.txt (AMD SEV-SNP os_image_hash)

### DIFF
--- a/mkimage.sh
+++ b/mkimage.sh
@@ -301,25 +301,28 @@ sha256sum sha256sum.txt | awk '{print $1}' > digest.txt
 popd
 
 # digest.sev.txt: the AMD SEV-SNP os_image_hash. Unlike the TDX digest.txt
-# (a content hash that includes the TDX firmware), this is computed by
-# dstack-vmm from the SEV firmware (ovmf-sev.fd) + kernel/initrd/cmdline/rootfs
-# and matches the os_image_hash the KMS verifier derives from a launch
-# measurement. Only emitted when the SEV firmware shipped and the tool exists.
+# (a content hash that includes the TDX firmware), this is computed by the
+# `dstack-mr` tool from the SEV firmware (ovmf-sev.fd) + kernel/initrd/cmdline/
+# rootfs and matches the os_image_hash the KMS verifier derives from a launch
+# measurement. The VMM reads this file at deploy time instead of recomputing it,
+# so it is required (not best-effort): if `dstack-mr` is not prebuilt, build it.
 HAVE_DIGEST_SEV=0
 if [ "$HAVE_OVMF_SEV" = "1" ]; then
-    if [ -z "${DSTACK_VMM_BIN:-}" ]; then
-        for c in "$SCRIPT_DIR/dstack-vmm" "$SCRIPT_DIR/rust-target/release/dstack-vmm" \
-                 "$SCRIPT_DIR/dstack/target/release/dstack-vmm"; do
-            [ -x "$c" ] && DSTACK_VMM_BIN="$c" && break
+    DSTACK_SRC="${DSTACK_SRC:-$SCRIPT_DIR/dstack}"
+    if [ -z "${DSTACK_MR_BIN:-}" ]; then
+        for c in "$SCRIPT_DIR/dstack-mr" "$SCRIPT_DIR/rust-target/release/dstack-mr" \
+                 "$DSTACK_SRC/target/release/dstack-mr"; do
+            [ -x "$c" ] && DSTACK_MR_BIN="$c" && break
         done
     fi
-    if [ -n "${DSTACK_VMM_BIN:-}" ] && [ -x "${DSTACK_VMM_BIN}" ]; then
-        echo "Generating digest.sev.txt via ${DSTACK_VMM_BIN}"
-        "${DSTACK_VMM_BIN}" sev-os-image-hash "${OUTPUT_DIR}" > "${OUTPUT_DIR}/digest.sev.txt"
-        HAVE_DIGEST_SEV=1
-    else
-        echo "Warning: dstack-vmm not found; skipping digest.sev.txt (set DSTACK_VMM_BIN)" >&2
+    if [ -z "${DSTACK_MR_BIN:-}" ]; then
+        echo "Building dstack-mr to compute digest.sev.txt"
+        ( cd "$DSTACK_SRC" && cargo build --release -p dstack-mr )
+        DSTACK_MR_BIN="$DSTACK_SRC/target/release/dstack-mr"
     fi
+    echo "Generating digest.sev.txt via ${DSTACK_MR_BIN}"
+    "${DSTACK_MR_BIN}" sev-os-image-hash "${OUTPUT_DIR}" > "${OUTPUT_DIR}/digest.sev.txt"
+    HAVE_DIGEST_SEV=1
 fi
 
 # Create UKI artifacts (disk.raw and auth_hash.txt) in OUTPUT_DIR

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -300,6 +300,28 @@ sha256sum ovmf.fd bzImage initramfs.cpio.gz metadata.json > sha256sum.txt
 sha256sum sha256sum.txt | awk '{print $1}' > digest.txt
 popd
 
+# digest.sev.txt: the AMD SEV-SNP os_image_hash. Unlike the TDX digest.txt
+# (a content hash that includes the TDX firmware), this is computed by
+# dstack-vmm from the SEV firmware (ovmf-sev.fd) + kernel/initrd/cmdline/rootfs
+# and matches the os_image_hash the KMS verifier derives from a launch
+# measurement. Only emitted when the SEV firmware shipped and the tool exists.
+HAVE_DIGEST_SEV=0
+if [ "$HAVE_OVMF_SEV" = "1" ]; then
+    if [ -z "${DSTACK_VMM_BIN:-}" ]; then
+        for c in "$SCRIPT_DIR/dstack-vmm" "$SCRIPT_DIR/rust-target/release/dstack-vmm" \
+                 "$SCRIPT_DIR/dstack/target/release/dstack-vmm"; do
+            [ -x "$c" ] && DSTACK_VMM_BIN="$c" && break
+        done
+    fi
+    if [ -n "${DSTACK_VMM_BIN:-}" ] && [ -x "${DSTACK_VMM_BIN}" ]; then
+        echo "Generating digest.sev.txt via ${DSTACK_VMM_BIN}"
+        "${DSTACK_VMM_BIN}" sev-os-image-hash "${OUTPUT_DIR}" > "${OUTPUT_DIR}/digest.sev.txt"
+        HAVE_DIGEST_SEV=1
+    else
+        echo "Warning: dstack-vmm not found; skipping digest.sev.txt (set DSTACK_VMM_BIN)" >&2
+    fi
+fi
+
 # Create UKI artifacts (disk.raw and auth_hash.txt) in OUTPUT_DIR
 UKI_CREATED=0
 if [ "$ENABLE_UKI_IMAGE" = "1" ]; then
@@ -330,6 +352,9 @@ if [ x$DSTACK_TAR_RELEASE = x1 ]; then
     BARE_METAL_FILES="rootfs.img.parted.verity bzImage ovmf.fd digest.txt sha256sum.txt initramfs.cpio.gz metadata.json"
     if [ "$HAVE_OVMF_SEV" = "1" ]; then
         BARE_METAL_FILES="$BARE_METAL_FILES ovmf-sev.fd"
+    fi
+    if [ "$HAVE_DIGEST_SEV" = "1" ]; then
+        BARE_METAL_FILES="$BARE_METAL_FILES digest.sev.txt"
     fi
     (cd "$PARENT_DIR" && tar -czvf ${IMAGE_TAR} $(for f in $BARE_METAL_FILES; do echo "$TAR_DIR_NAME/$f"; done))
     echo


### PR DESCRIPTION
## What

Emit `digest.sev.txt` next to `digest.txt` when the image ships the AMD SEV firmware (`ovmf-sev.fd`). It is the **AMD SEV-SNP `os_image_hash`** — the image identity used for SEV attestation / on-chain allow-listing.

## Why a separate digest

`digest.txt` (TDX) is `sha256(sha256sum.txt)` over the artifacts incl. **`ovmf.fd` (the TDX firmware)** — wrong firmware for SEV. For SEV, the meaningful identity is the **image-invariant projection of the SNP launch measurement**: `ovmf-sev.fd` launch digest + kernel/initrd/cmdline/rootfs hashes, excluding per-deployment params (vCPUs, etc.).

So `digest.sev.txt` is computed by `dstack-vmm sev-os-image-hash <image-dir>` and **matches the `os_image_hash` the KMS verifier derives from a launch measurement** (both go through the shared `dstack_types::SevOsImageMeasurement`; a unit test in dstack cross-checks the two paths).

## Changes

- `mkimage.sh`: when `HAVE_OVMF_SEV`, run `dstack-vmm sev-os-image-hash` → `digest.sev.txt`, and add it to the bare-metal tarball. Gracefully skipped (warning) if the SEV firmware is absent or the tool isn't built; path overridable via `DSTACK_VMM_BIN`.

## Depends on

The dstack-side tooling (shared `SevOsImageMeasurement` + `sev-os-image-hash` subcommand + the os_image_hash vCPU-independence fix) in Dstack-TEE/dstack PR #728. `build.sh`'s `build_host` already builds `dstack-vmm` to the repo root.

## Verification

`make dist` (dev flavor) produced:
```
digest.txt      40a14f51...   (TDX, unchanged scheme)
digest.sev.txt  80e08e3e...   (SEV os_image_hash)
```
`digest.sev.txt` equals the standalone `dstack-vmm sev-os-image-hash` output and (per the dstack cross-check test) the KMS-derived `os_image_hash`.