### PR TITLE
build: drop separate NVIDIA flavors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ DIST_DIR ?= ${BB_BUILD_DIR}/dist
 export BB_BUILD_DIR
 export DIST_DIR
 
-# Flavor names map to multiconfig names: prod, dev, nvidia, nvidia-dev
-FLAVORS ?= prod dev nvidia nvidia-dev
+# Flavor names map to multiconfig names: prod, dev
+FLAVORS ?= prod
 
 # Map flavor to dist name for mkimage.sh
-flavor_to_dist = $(if $(filter prod,$1),dstack,$(if $(filter dev,$1),dstack-dev,$(if $(filter nvidia,$1),dstack-nvidia,$(if $(filter nvidia-dev,$1),dstack-nvidia-dev,$1))))
+flavor_to_dist = $(if $(filter prod,$1),dstack,$(if $(filter dev,$1),dstack-dev,$1))
 
 all: dist
 

--- a/build.sh
+++ b/build.sh
@@ -340,17 +340,15 @@ Actions:
   all      - Build everything (host, guest, and configuration)
   help     - Show this help
 
-Build a specific guest flavor (default builds all four): set the FLAVORS env var.
+Build a specific guest flavor (default builds production): set the FLAVORS env var.
   flavor      -> output image
   prod        -> dstack
   dev         -> dstack-dev
-  nvidia      -> dstack-nvidia
-  nvidia-dev  -> dstack-nvidia-dev
 
   Examples:
-    FLAVORS=nvidia ./build.sh guest          # build only dstack-nvidia
-    FLAVORS="prod nvidia" ./build.sh guest   # build two flavors
-    ./build.sh guest                         # build all flavors (default)
+    ./build.sh guest                     # build dstack (default)
+    FLAVORS=dev ./build.sh guest         # build only dstack-dev
+    FLAVORS="prod dev" ./build.sh guest  # build both flavors
 EOF
 }
 

--- a/meta-dstack/conf/distro/dstack.conf
+++ b/meta-dstack/conf/distro/dstack.conf
@@ -25,7 +25,7 @@ SERIAL_CONSOLES = "115200;ttyS0"
 PREFERRED_VERSION_rust-bin-cross-x86_64 = "1.92.0"
 PREFERRED_VERSION_cargo-bin-cross-x86_64 = "1.92.0"
 
-# NVIDIA driver stack (only consulted when nvidia flavor is built).
+# NVIDIA driver stack (included in the default images).
 # Bump all three together — kernel module ABI is paired with userspace libs.
 NVIDIA_VERSION = "595.58.03"
 PREFERRED_VERSION_nvidia = "${NVIDIA_VERSION}"

--- a/meta-dstack/conf/local.conf
+++ b/meta-dstack/conf/local.conf
@@ -296,4 +296,4 @@ SOURCE_MIRROR_URL = "https://mirrors.kernel.org/yocto-sources/"
 
 # Improve resilience for large files on unstable links
 FETCHCMD_wget = "wget --progress=dot --inet4-only -c"
-BBMULTICONFIG = "prod dev nvidia nvidia-dev"
+BBMULTICONFIG = "prod dev"

--- a/meta-dstack/conf/multiconfig/dev.conf
+++ b/meta-dstack/conf/multiconfig/dev.conf
@@ -1,6 +1,5 @@
 # Development flavor configuration
 DSTACK_FLAVOR = "dev"
-DSTACK_NVIDIA = "0"
 DSTACK_DEV = "1"
 
 # Use separate TMPDIR to avoid conflicts between multiconfigs

--- a/meta-dstack/conf/multiconfig/nvidia-dev.conf
+++ b/meta-dstack/conf/multiconfig/nvidia-dev.conf
@@ -1,7 +1,0 @@
-# NVIDIA development flavor configuration
-DSTACK_FLAVOR = "nvidia-dev"
-DSTACK_NVIDIA = "1"
-DSTACK_DEV = "1"
-
-# Use separate TMPDIR to avoid conflicts between multiconfigs
-TMPDIR = "${TOPDIR}/tmp-mc-nvidia-dev"

--- a/meta-dstack/conf/multiconfig/nvidia.conf
+++ b/meta-dstack/conf/multiconfig/nvidia.conf
@@ -1,7 +1,0 @@
-# NVIDIA production flavor configuration
-DSTACK_FLAVOR = "nvidia"
-DSTACK_NVIDIA = "1"
-DSTACK_DEV = "0"
-
-# Use separate TMPDIR to avoid conflicts between multiconfigs
-TMPDIR = "${TOPDIR}/tmp-mc-nvidia"

--- a/meta-dstack/conf/multiconfig/prod.conf
+++ b/meta-dstack/conf/multiconfig/prod.conf
@@ -1,6 +1,5 @@
 # Production flavor configuration
 DSTACK_FLAVOR = "prod"
-DSTACK_NVIDIA = "0"
 DSTACK_DEV = "0"
 
 # Use separate TMPDIR to avoid conflicts between multiconfigs

--- a/meta-dstack/recipes-core/images/dstack-rootfs-nvidia.inc
+++ b/meta-dstack/recipes-core/images/dstack-rootfs-nvidia.inc
@@ -9,7 +9,10 @@ NVIDIA_GROUP = "acpid \
     kernel-module-video \
     numactl \
 "
-KERNEL_MODULE_AUTOLOAD:append = " nvidia nvidia-drm nvidia-modeset nvidia-uvm video"
+# Do not autoload NVIDIA modules on every boot. The default image also runs on
+# GPU-less hosts, so GPU services load these modules only after hardware
+# detection succeeds.
+KERNEL_MODULE_AUTOLOAD:append = " video"
 IMAGE_INSTALL:append = " ${NVIDIA_GROUP}"
 
 DOCKER_DAEMON_JSON = "${THISDIR}/files/docker-daemon-nvidia.json"

--- a/meta-dstack/recipes-core/images/dstack-rootfs.bb
+++ b/meta-dstack/recipes-core/images/dstack-rootfs.bb
@@ -1,10 +1,9 @@
 # Unified dstack rootfs image
 # Use DSTACK_FLAVOR (via multiconfig) to select variant:
-#   prod, dev, nvidia, nvidia-dev
+#   prod, dev
 
 # Default flavor settings (can be overridden by multiconfig)
 DSTACK_FLAVOR ?= "prod"
-DSTACK_NVIDIA ?= "0"
 DSTACK_DEV ?= "0"
 
 # Base configuration
@@ -13,5 +12,6 @@ include dstack-rootfs-base.inc
 # Production or development mode
 include ${@'dstack-rootfs-dev.inc' if d.getVar('DSTACK_DEV') == '1' else 'dstack-rootfs-prod.inc'}
 
-# NVIDIA support (optional)
-include ${@'dstack-rootfs-nvidia.inc' if d.getVar('DSTACK_NVIDIA') == '1' else ''}
+# NVIDIA support is included in all images; services are gated at runtime by
+# hardware-detection ExecCondition= checks so the same image works without GPUs.
+include dstack-rootfs-nvidia.inc

--- a/meta-nvidia/recipes-graphics/nvidia/files/nvidia-fabricmanager-nvswitch-condition.conf
+++ b/meta-nvidia/recipes-graphics/nvidia/files/nvidia-fabricmanager-nvswitch-condition.conf
@@ -4,3 +4,9 @@
 # not failed.
 [Service]
 ExecCondition=/usr/bin/nvidia-gpu-detect nvswitch
+# Load NVIDIA modules only after NVSwitch detection succeeds to avoid boot-time
+# modprobe failures/noise on GPU-less hosts.
+ExecStartPre=/usr/bin/env modprobe nvidia
+ExecStartPre=/usr/bin/env modprobe nvidia-modeset
+ExecStartPre=/usr/bin/env modprobe nvidia-drm
+ExecStartPre=/usr/bin/env modprobe nvidia-uvm

--- a/meta-nvidia/recipes-graphics/nvidia/files/nvidia-persistenced.service
+++ b/meta-nvidia/recipes-graphics/nvidia/files/nvidia-persistenced.service
@@ -9,6 +9,12 @@ Type=oneshot
 # Skip cleanly on instances without an NVIDIA GPU (exit 1 -> unit skipped, not
 # failed), so the NVIDIA image can run on GPU-less hosts.
 ExecCondition=/usr/bin/nvidia-gpu-detect gpu
+# Load NVIDIA modules only after GPU detection succeeds to avoid boot-time
+# modprobe failures/noise on GPU-less hosts.
+ExecStartPre=/usr/bin/env modprobe nvidia
+ExecStartPre=/usr/bin/env modprobe nvidia-modeset
+ExecStartPre=/usr/bin/env modprobe nvidia-drm
+ExecStartPre=/usr/bin/env modprobe nvidia-uvm
 ExecStart=/usr/bin/env nvidia-persistenced --uvm-persistence-mode
 ExecStartPost=/usr/bin/nvidia-smi conf-compute -srs 1
 RemainAfterExit=yes

--- a/meta-nvidia/recipes-graphics/nvidia/nvidia-fabricmanager_%.bbappend
+++ b/meta-nvidia/recipes-graphics/nvidia/nvidia-fabricmanager_%.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 # service is silently skipped (not failed) on non-NVSwitch instances.
 SRC_URI += "file://nvidia-fabricmanager-nvswitch-condition.conf"
 
-RDEPENDS:${PN} += "nvidia-gpu-detect"
+RDEPENDS:${PN} += "nvidia-gpu-detect kmod"
 
 do_install:append() {
     install -d ${D}${systemd_system_unitdir}/nvidia-fabricmanager.service.d

--- a/meta-nvidia/recipes-graphics/nvidia/nvidia-persistenced_1.0.bb
+++ b/meta-nvidia/recipes-graphics/nvidia/nvidia-persistenced_1.0.bb
@@ -9,7 +9,7 @@ S = "${UNPACKDIR}"
 
 inherit systemd
 
-RDEPENDS:${PN} += "nvidia-gpu-detect"
+RDEPENDS:${PN} += "nvidia-gpu-detect kmod"
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "nvidia-persistenced.service"

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -36,16 +36,30 @@ if [ -z "$DIST_NAME" ]; then
 fi
 
 if [ -z "$FLAVOR" ]; then
-    echo "Error: --flavor is required (prod, dev, nvidia, nvidia-dev)"
+    echo "Error: --flavor is required (prod, dev)"
     exit 1
 fi
 
-
-if [[ "$DIST_NAME" == *-dev ]]; then
-    IS_DEV=true
-else
-    IS_DEV=false
-fi
+case "$FLAVOR" in
+    prod)
+        if [[ "$DIST_NAME" == *-dev ]]; then
+            echo "Error: prod flavor requires a non-dev dist name: $DIST_NAME" >&2
+            exit 1
+        fi
+        IS_DEV=false
+        ;;
+    dev)
+        if [[ "$DIST_NAME" != *-dev ]]; then
+            echo "Error: dev flavor requires a dist name ending in -dev: $DIST_NAME" >&2
+            exit 1
+        fi
+        IS_DEV=true
+        ;;
+    *)
+        echo "Error: unsupported --flavor '$FLAVOR' (expected prod or dev)" >&2
+        exit 1
+        ;;
+esac
 
 BB_BUILD_DIR=$(realpath ${BB_BUILD_DIR:-build})
 DIST_DIR=$(realpath ${DIST_DIR:-${BB_BUILD_DIR}/dist})

--- a/repro-build/repro-build.sh
+++ b/repro-build/repro-build.sh
@@ -4,6 +4,10 @@ set -e
 usage() {
     echo "Usage: $0 [-n]"
     echo "  -n: Don't check reproducibility"
+    echo ""
+    echo "Environment:"
+    echo "  RELEASE_FLAVORS: space-separated flavors to build (default: prod)"
+    echo "                  e.g. RELEASE_FLAVORS=\"prod dev\" $0"
 }
 
 NO_CHECK=0
@@ -51,8 +55,8 @@ build_to() {
         $BUILDER_NAME bash -e -c "$BUILD_CMD"
 }
 
-# Only build production flavors (no dev) for reproducible builds
-RELEASE_FLAVORS="prod nvidia"
+# Build production by default; callers may override, e.g. RELEASE_FLAVORS="prod dev".
+RELEASE_FLAVORS="${RELEASE_FLAVORS:-prod}"
 
 build_to $HOST_BUILD_DIR_A "FLAVORS='$RELEASE_FLAVORS' DSTACK_TAR_RELEASE=1"
 
@@ -79,7 +83,7 @@ git clone https://github.com/Phala-Network/meta-dstack-cloud.git
 cd meta-dstack-cloud/
 git checkout $(git -C $THIS_DIR rev-parse HEAD)
 git submodule update --init --recursive
-cd repro-build && ./repro-build.sh -n
+cd repro-build && RELEASE_FLAVORS='${RELEASE_FLAVORS}' ./repro-build.sh -n
 EOF
 echo "==========================="
 

--- a/scripts/bin/mk-image-mr.sh
+++ b/scripts/bin/mk-image-mr.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Function to display usage
 usage() {
     echo "Usage: $0 <url_or_local_file>"
-    echo "Example: $0 https://github.com/nearai/private-ml-sdk/releases/download/v0.5.3.1/dstack-nvidia-0.5.3.1.tar.gz"
+    echo "Example: $0 https://github.com/Dstack-TEE/meta-dstack/releases/download/v0.6.0/dstack-0.6.0.tar.gz"
     echo "Example: $0 /path/to/local/file.tar.gz"
     exit 1
 }


### PR DESCRIPTION
## Summary
- include NVIDIA support in the default prod/dev rootfs images
- remove the separate `nvidia` and `nvidia-dev` multiconfig flavors/dist outputs
- default `FLAVORS` to `prod` only; `dev` remains available via `FLAVORS=dev` or `FLAVORS="prod dev"`
- allow reproducible builds to override `RELEASE_FLAVORS` while defaulting to `prod`
- validate `mkimage.sh` flavor/dist-name consistency so dev metadata follows `--flavor`
- avoid unconditional NVIDIA module autoloading on GPU-less hosts; GPU/NVSwitch-gated services load modules only after hardware detection succeeds

## Testing
- `git diff --check`
- `bash -n build.sh mkimage.sh repro-build/repro-build.sh scripts/bin/mk-image-mr.sh`
- `sh -n meta-nvidia/recipes-graphics/nvidia/files/nvidia-gpu-detect`
- `BBPATH=/tmp make -n dist`
- `BBPATH=/tmp make -n dist FLAVORS=prod`
- `BBPATH=/tmp make -n dist FLAVORS="prod dev"`
- `./mkimage.sh --dist-name dstack --flavor dev` fails with the expected mismatch error
- `./mkimage.sh --dist-name dstack-dev --flavor prod` fails with the expected mismatch error
- `git grep -n -E 'DSTACK_NVIDIA|nvidia-dev|dstack-nvidia|mc:nvidia|prod nvidia|prod dev nvidia|default builds all four|nvidia flavor|nvidia, nvidia-dev|all four' -- . ':(exclude)dstack'`
