### PR TITLE
chrony: enable NTS packageconfig

### DIFF
--- a/meta-dstack/recipes-core/chrony/chrony%.bbappend
+++ b/meta-dstack/recipes-core/chrony/chrony%.bbappend
@@ -1,3 +1,4 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 DEPENDS += "gnutls"
+PACKAGECONFIG:append = " nts"


### PR DESCRIPTION
## Summary

- Explicitly enable chrony's `nts` PACKAGECONFIG in the dstack layer.
- This makes the shipped `server ... nts` chrony configuration actually build with NTS support after the Yocto/meta-openembedded upgrade.

## Why

Newer meta-openembedded chrony recipes gate NTS behind `PACKAGECONFIG[nts] = ",--disable-nts,gnutls"`. Without `nts` in `PACKAGECONFIG`, bitbake passes `--disable-nts` even though our bbappend adds `gnutls` to `DEPENDS`.

That leaves `chronyd` built with `-NTS`, so `secure_time: true` can fail waiting for chrony to synchronize. See Dstack-TEE/dstack#745.

## Test

```console
$ source ./dev-setup >/tmp/dev-setup-chrony-pr.log
$ bitbake -e mc:prod:chrony | grep -E '^(PACKAGECONFIG=|PACKAGECONFIG_CONFARGS=|DEPENDS=)'
DEPENDS="pkgconf-native gcc-cross-x86_64 virtual/compilerlibs virtual/libc pps-tools gnutls libedit gnutls systemd-systemctl-native"
PACKAGECONFIG="editline     ipv6  nts"
PACKAGECONFIG_CONFARGS=" --disable-privdrop --without-seccomp --disable-sechash"
```
