### PR TITLE
[codex] Add AWS EC2 Nitro image support

### DIFF
--- a/meta-dstack/recipes-core/dstack-guest/dstack-guest.bb
+++ b/meta-dstack/recipes-core/dstack-guest/dstack-guest.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "${SUMMARY}"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
-inherit systemd
+inherit systemd pkgconfig
 
 REPO_ROOT = "${THISDIR}/../../.."
 
@@ -13,7 +13,7 @@ S = "${UNPACKDIR}/dstack"
 
 RDEPENDS:${PN} += "bash"
 
-DEPENDS += "rsync-native"
+DEPENDS += "rsync-native tpm2-tss"
 
 # Ensure rsync-native is built before unpack runs
 do_unpack[depends] += "rsync-native:do_populate_sysroot"

--- a/meta-dstack/recipes-kernel/linux/files/dstack-aws.cfg
+++ b/meta-dstack/recipes-kernel/linux/files/dstack-aws.cfg
@@ -1,0 +1,24 @@
+# AWS EC2 Nitro boot support.
+#
+# EC2 Nitro EBS root volumes appear as NVMe block devices. The dstack initramfs
+# resolves the dm-verity root partition before the rootfs is available, so the
+# block driver must be built into the kernel.
+CONFIG_NVME_CORE=y
+CONFIG_BLK_DEV_NVME=y
+
+# ENA is the EC2 Nitro network device. Keep it built-in so early userspace and
+# systemd can bring networking up without relying on rootfs module loading.
+CONFIG_NET_VENDOR_AMAZON=y
+CONFIG_ENA_ETHERNET=y
+
+# EC2 boots the raw disk as an UEFI/GPT image and exposes logs through ttyS0.
+CONFIG_EFI=y
+CONFIG_EFI_STUB=y
+CONFIG_EFI_PARTITION=y
+CONFIG_SERIAL_8250=y
+CONFIG_SERIAL_8250_CONSOLE=y
+CONFIG_SERIAL_8250_PCI=y
+
+# NitroTPM uses the TPM 2.0 CRB interface.
+CONFIG_TCG_TPM=y
+CONFIG_TCG_CRB=y

--- a/meta-dstack/recipes-kernel/linux/files/dstack-aws.scc
+++ b/meta-dstack/recipes-kernel/linux/files/dstack-aws.scc
@@ -1,0 +1,3 @@
+define KFEATURE_DESCRIPTION "dstack AWS EC2 Nitro configuration"
+
+kconf hardware dstack-aws.cfg

--- a/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
+++ b/meta-dstack/recipes-kernel/linux/linux-yocto%.bbappend
@@ -4,6 +4,8 @@ LINUX_VERSION_EXTENSION = "-dstack"
 
 SRC_URI += "file://dstack-docker.cfg \
             file://dstack-docker.scc \
+            file://dstack-aws.cfg \
+            file://dstack-aws.scc \
             file://dstack-tdx.cfg \
             file://dstack-tdx.scc \
             file://dstack-sysbox.cfg \
@@ -57,6 +59,7 @@ KERNEL_FEATURES:append:dstack = " features/scsi/disk.scc \
                                   hyperv.scc \
                                   security-mitigations.scc \
                                   disk-encryption.scc \
+                                  dstack-aws.scc \
                                   dstack-tdx.scc"
 
 # disk-encryption.scc (above, from meta-confidential-compute) ships dm-crypt


### PR DESCRIPTION
## Summary

Adds the Yocto layer pieces needed for AWS EC2 NitroTPM boot support.

This includes:
- a `dstack-aws` kernel feature fragment for EC2 Nitro devices;
- built-in NVMe root disk support for EBS root volumes;
- built-in ENA networking support;
- UEFI/GPT and serial console support for EC2 boot/debugging;
- built-in TPM CRB support for NitroTPM;
- `tpm2-tss` as a `dstack-guest` build dependency.

Depends on the dstack platform implementation in Dstack-TEE/dstack#753.

## Validation

- `git diff --cached --check` before commit
- the AWS hardened image was built on `phala-onprem` rather than locally
- live EC2 smoke passed against the promoted Attestable AMI recorded in Dstack-TEE/dstack#753

## Notes

The local checkout still has a dirty nested `dstack` submodule working tree from the implementation/testing workspace. This PR intentionally commits only the meta-layer recipe and kernel feature changes; the dstack code changes live in Dstack-TEE/dstack#753.